### PR TITLE
Add "dhtml" function to @corpuscule/element

### DIFF
--- a/packages/element/__tests__/dhtml.ts
+++ b/packages/element/__tests__/dhtml.ts
@@ -1,0 +1,112 @@
+// tslint:disable:await-promise max-classes-per-file
+import {TemplateResult} from "lit-html";
+// tslint:disable-next-line:no-implicit-dependencies
+import uuid from "uuid/v4";
+import {defineAndMount} from "../../../test/utils";
+import CorpusculeElement, {render} from "../src";
+import dhtml, {unsafeStatic} from "../src/dhtml";
+
+const testDhtml = () => {
+  describe("dhtml", () => {
+    it("should render CorpusculeElement into template", async () => {
+      class Test1 extends CorpusculeElement {
+        public static readonly is: string = `x-${uuid()}`;
+
+        protected [render](): TemplateResult | null {
+          return dhtml`<div>Test content</div>`;
+        }
+      }
+
+      customElements.define(Test1.is, Test1);
+
+      class Test2 extends CorpusculeElement {
+        public static readonly is: string = `x-${uuid()}`;
+
+        protected [render](): TemplateResult | null {
+          return dhtml`<${Test1}/>`;
+        }
+      }
+
+      const el = defineAndMount(Test2);
+      await el.elementRendering;
+
+      const inner: Test1 | null = el.shadowRoot!.querySelector(Test1.is);
+      await inner!.elementRendering;
+
+      expect(inner).not.toBeNull();
+      expect(inner!.shadowRoot!.textContent).toContain("Test content");
+    });
+
+    it("should render string marked with tag() directive into template", async () => {
+      const section = unsafeStatic("section");
+
+      class Test extends CorpusculeElement {
+        public static readonly is: string = `x-${uuid()}`;
+
+        protected [render](): TemplateResult | null {
+          return dhtml`<${section}>Test content</${section}>`;
+        }
+      }
+
+      const el = defineAndMount(Test);
+      await el.elementRendering;
+
+      const inner = el.shadowRoot!.querySelector("section");
+      expect(inner).not.toBeNull();
+      expect(inner!.textContent).toContain("Test content");
+    });
+
+    it("should work properly with complex nesting", async () => {
+      class Test1 extends CorpusculeElement {
+        public static readonly is: string = `x-${uuid()}`;
+
+        protected [render](): TemplateResult | null {
+          return dhtml`<div><slot/></div>`;
+        }
+      }
+
+      customElements.define(Test1.is, Test1);
+
+      class Test2 extends CorpusculeElement {
+        public static readonly is: string = `x-${uuid()}`;
+
+        protected [render](): TemplateResult | null {
+          const testContentText = "Test content";
+          const nestedTwiceText = "Nested twice";
+
+          return dhtml`
+            <${Test1}>
+              <div>Nested simple</div>
+              ${testContentText}
+              <${Test1}>
+                Nested Test
+                <section>${nestedTwiceText}</section>
+              </${Test1}>
+            </${Test1}>`;
+        }
+      }
+
+      const el = defineAndMount(Test2);
+      await el.elementRendering;
+
+      const container = el.shadowRoot!.querySelector(Test1.is)!;
+      expect(container).not.toBeNull();
+      expect(container).toEqual(jasmine.any(Test1));
+      expect(container.textContent).toContain("Test content");
+
+      const nestedSimple = container.querySelector("div")!;
+      expect(nestedSimple).not.toBeNull();
+      expect(nestedSimple.textContent).toContain("Nested simple");
+
+      const nestedContainer = container.querySelector(Test1.is)!;
+      expect(nestedContainer).not.toBeNull();
+      expect(nestedContainer.textContent).toContain("Nested Test");
+
+      const nestedTwice = nestedContainer.querySelector("section")!;
+      expect(nestedTwice).not.toBeNull();
+      expect(nestedTwice.textContent).toContain("Nested twice");
+    });
+  });
+};
+
+export default testDhtml;

--- a/packages/element/__tests__/index.ts
+++ b/packages/element/__tests__/index.ts
@@ -1,6 +1,7 @@
 import testCreateComputingEntanglement from "./computed";
 import testCorpusculeElement from "./corpusculeElement";
 import testDecorators from "./decorators";
+import testDhtml from "./dhtml";
 import testScheduler from "./scheduler";
 
 describe("@corpuscule/element", () => {
@@ -8,6 +9,7 @@ describe("@corpuscule/element", () => {
     document.body.innerHTML = ""; // tslint:disable-line:no-inner-html
   });
 
+  testDhtml();
   testCorpusculeElement();
   testDecorators();
   testCreateComputingEntanglement();

--- a/packages/element/src/dhtml.d.ts
+++ b/packages/element/src/dhtml.d.ts
@@ -1,0 +1,13 @@
+import {TemplateResult} from "lit-html";
+
+export class UnsafeStatic {
+  public readonly value: unknown;
+
+  public constructor(value: unknown);
+}
+
+export const unsafeStatic: (value: unknown) => UnsafeStatic;
+
+// tslint:disable-next-line:array-type readonly-array
+declare const dhtml: (strings: ReadonlyArray<string>, ...values: unknown[]) => TemplateResult;
+export default dhtml;

--- a/packages/element/src/dhtml.js
+++ b/packages/element/src/dhtml.js
@@ -1,0 +1,63 @@
+/* eslint-disable max-depth */
+
+import {html} from "lit-html";
+
+const registry = new Map();
+
+export class UnsafeStatic {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+export const unsafeStatic = value => new UnsafeStatic(value);
+
+const isElementOrUnsafeStatic = value => typeof value.is === "string" || value instanceof UnsafeStatic;
+
+const dhtml = (strings, ...values) => {
+  const record = registry.get(strings);
+
+  let recordStrings;
+  let valueIndexesToFilter;
+
+  if (!record) {
+    valueIndexesToFilter = [];
+
+    if (values.some(isElementOrUnsafeStatic)) {
+      recordStrings = [];
+
+      let previousValueWasStatic = false;
+
+      for (let i = 0; i < strings.length; i++) {
+        if (previousValueWasStatic) {
+          recordStrings[recordStrings.length - 1] += strings[i];
+        } else {
+          recordStrings.push(strings[i]);
+        }
+
+        if (i < strings.length - 1 && isElementOrUnsafeStatic(values[i])) {
+          recordStrings[recordStrings.length - 1] += values[i].is || String(values[i].value);
+          valueIndexesToFilter.push(i);
+          previousValueWasStatic = true;
+        } else {
+          previousValueWasStatic = false;
+        }
+      }
+    } else {
+      recordStrings = strings;
+    }
+
+    registry.set(strings, [recordStrings, valueIndexesToFilter]);
+  } else {
+    [recordStrings, valueIndexesToFilter] = record;
+  }
+
+  return html(
+    recordStrings,
+    ...valueIndexesToFilter.length > 0
+      ? values.filter((_, i) => !valueIndexesToFilter.includes(i))
+      : values,
+  );
+};
+
+export default dhtml;

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -2,6 +2,7 @@ const packages = {
   context: ["index"],
   element: [
     "computed",
+    "dhtml",
     "index",
   ],
   redux: ["index"],


### PR DESCRIPTION
For now `lit-html`'s `html` function doesn't have ability to use static values like tag names. If you use custom elements, it is terribly inconvenient, because you need to work with strings instead of program symbols like class definitions or variables. 

Compare two cases. Which is more convenient?
```javascript
import {html} from "lit-html";
import "./my-element";

class App extends CorpusculeElement {
  [render]() {
    return html`<my-element>Some content</my-element>`;
  }
}
```

```javascript
import {html} from "lit-html";
import MyElement from "./my-element";

class App extends CorpusculeElement {
  [render]() {
    return html`<${MyElement}>Some content</${MyElement}>`;
  }
}
```
The second variant is definitely winning. It imports not a file but class definition, and uses this definition to describe tag. It is less buggy: if you didn't import something tools like webpack or typescript could catch it during the compilation while the first variant can fail only at runtime.

This PR adds this functionality to the `@corpuscule/element`. `dhtml` function that can be imported from `@corpuscule/element/lib/dhtml` module is a simple wrapper over the `html` function that provides missing functional. It is a re-implementation of [Add unsafeStatic values](https://github.com/Polymer/lit-html/pull/274) PR for `lit-html` that uses simple `Map` for cache.

Usage of the function is pretty simple. Import a `dhtml` function along with `unsafeStatic` directive from `@corpuscule/element/lib/dhtml`, wrap any of your unsafe static value and send it to the `dhtml` function.

### Example
```javascript
import {dhtml, unsafeStatic} from "@corpuscule/element/lib/dhtml";
import MyElementClass from "./my-element";

const MyElement = unsafeStatic(MyElementClass.is);

class App extends CorpusculeElement {
  [render]() {
    return dhtml`<${MyElement}>Some content</${MyElement}>`;
  }
}
```

### Bonus
To reduce boilerplate you can use special CorpusculeElement static value that returns already created `unsafeStatic` value `tag` for each element you marked with an `@element` decorator.

```javascript
import {dhtml} from "@corpuscule/element/lib/dhtml";
import MyElement from "./my-element";

class App extends CorpusculeElement {
  [render]() {
    return dhtml`<${MyElement.tag}>Some content</${MyElement.tag}>`;
  }
}
```