### PR TITLE
Replace throw condition with correctness condition for "assertKind"

### DIFF
--- a/packages/element/src/computed.js
+++ b/packages/element/src/computed.js
@@ -10,7 +10,7 @@ const createComputingEntanglement = () => {
     kind,
     placement,
   }) => {
-    assertKind("computed", "getter", kind, !get);
+    assertKind("computed", "getter", kind, !!get);
 
     return {
       descriptor: {
@@ -53,7 +53,7 @@ const createComputingEntanglement = () => {
 
   const observe = (descriptor) => {
     const {key, kind} = descriptor;
-    assertKind("observe", "field or method", kind, kind !== "field" && kind !== "method");
+    assertKind("observe", "field or method", kind, kind === "field" || kind === "method");
 
     observables.push(key);
 

--- a/packages/redux/src/decorators.js
+++ b/packages/redux/src/decorators.js
@@ -22,7 +22,7 @@ export const dispatcher = ({
   kind,
   placement,
 }) => {
-  assertKind("dispatcher", "field or method", kind, kind !== "method" && kind !== "field");
+  assertKind("dispatcher", "field or method", kind, kind === "method" || kind === "field");
 
   if (kind === "field") {
     const initialized = initializer ? initializer() : undefined;

--- a/packages/utils/__tests__/assertKind.ts
+++ b/packages/utils/__tests__/assertKind.ts
@@ -10,7 +10,7 @@ const assertKindTest = () => {
 
     it("should throw an error when shouldThrow is specified and true", () => {
       expect(() => {
-        assertKind("foo", "getter", "method", true); // descriptor.get is undefined
+        assertKind("foo", "getter", "method", false); // descriptor.get is undefined
       }).toThrow(new TypeError("@foo can be applied only to getter, not to method"));
     });
 
@@ -22,7 +22,7 @@ const assertKindTest = () => {
 
     it("should not throw an error when shouldThrow is specified and false", () => {
       expect(() => {
-        assertKind("foo", "getter", "method", false); // descriptor.get exists
+        assertKind("foo", "getter", "method", true); // descriptor.get exists
       }).not.toThrow();
     });
   });

--- a/packages/utils/src/assertKind.d.ts
+++ b/packages/utils/src/assertKind.d.ts
@@ -1,3 +1,3 @@
-declare const assertKind: (decoratorName: string, expectedKind: string, receivedKind: string, shouldThrow?: boolean) => void;
+declare const assertKind: (decoratorName: string, expectedKind: string, receivedKind: string, correct?: boolean) => void;
 
 export default assertKind;

--- a/packages/utils/src/assertKind.js
+++ b/packages/utils/src/assertKind.js
@@ -2,9 +2,9 @@ const assertKind = (
   decoratorName,
   expectedKind,
   receivedKind,
-  shouldThrow = expectedKind !== receivedKind,
+  correct = expectedKind === receivedKind,
 ) => {
-  if (shouldThrow) {
+  if (!correct) {
     throw new TypeError(`@${decoratorName} can be applied only to ${expectedKind}, not to ${receivedKind}`);
   }
 };


### PR DESCRIPTION
Using positive condition for `assertKind` function is more obvious and convenient than negative. 