### PR TITLE
Rewrite tests to use HTMLElementMock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12388,9 +12388,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "version": "3.2.1",
+      "resolved": "https://eis.jfrog.io/eis/api/npm/npm/typescript/-/typescript-3.2.1.tgz",
+      "integrity": "sha1-C3oEuM84aBiN6RTZVovQMPDFYZI=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ts-loader": "^5.1.1",
     "tslint": "^5.11.0",
     "tslint-config-poetez": "^1.1.1",
-    "typescript": "^3.0.3",
+    "typescript": "^3.2.1",
     "universal-router": "^6.0.0",
     "uuid": "^3.3.2",
     "webpack": "^4.19.1"

--- a/packages/context/__tests__/index.ts
+++ b/packages/context/__tests__/index.ts
@@ -1,7 +1,26 @@
 // tslint:disable:max-classes-per-file
 // tslint:disable-next-line:no-implicit-dependencies
-import {HTMLElementMock} from '../../../test/utils';
+import {Constructor, HTMLElementMock} from '../../../test/utils';
 import createContext from '../src';
+
+export const createContextElements = <T extends HTMLElementMock, U extends HTMLElementMock>(
+  providerConstructor: Constructor<T>,
+  consumerConstructor: Constructor<U>,
+  consumersNumber: number = 1,
+) => { // tslint:disable-line:readonly-array
+  const consumers = new Array(consumersNumber);
+  const provider = new providerConstructor();
+  provider.connectedCallback();
+
+  for (let i = 0; i < consumersNumber; i++) { // tslint:disable-line:no-increment-decrement
+    consumers[i] = new consumerConstructor();
+
+    consumers[i].addParent(provider);
+    consumers[i].connectedCallback();
+  }
+
+  return [provider, ...consumers];
+};
 
 describe('@corpuscule/context', () => {
   describe('createContext', () => {
@@ -23,13 +42,7 @@ describe('@corpuscule/context', () => {
         public [contextValue]: number;
       }
 
-      const providerElement = new Provider();
-      const consumerElement = new Consumer();
-
-      consumerElement.addParent(providerElement);
-
-      providerElement.connectedCallback();
-      consumerElement.connectedCallback();
+      const [, consumerElement] = createContextElements(Provider, Consumer);
       expect(consumerElement[contextValue]).toBe(2);
     });
 
@@ -51,16 +64,7 @@ describe('@corpuscule/context', () => {
         public [contextValue]: number;
       }
 
-      const providerElement = new Provider();
-      const consumerElement1 = new Consumer();
-      const consumerElement2 = new Consumer();
-
-      consumerElement1.addParent(providerElement);
-      consumerElement2.addParent(providerElement);
-
-      providerElement.connectedCallback();
-      consumerElement1.connectedCallback();
-      consumerElement2.connectedCallback();
+      const [, consumerElement1, consumerElement2] = createContextElements(Provider, Consumer, 2);
 
       expect(consumerElement1[contextValue]).toBe(2);
       expect(consumerElement2[contextValue]).toBe(2);
@@ -84,13 +88,7 @@ describe('@corpuscule/context', () => {
         public [contextValue]: number;
       }
 
-      const providerElement = new Provider();
-      const consumerElement = new Consumer();
-
-      consumerElement.addParent(providerElement);
-
-      providerElement.connectedCallback();
-      consumerElement.connectedCallback();
+      const [providerElement, consumerElement] = createContextElements(Provider, Consumer);
 
       expect(providerElement[providingValue]).toBe(2);
       expect(consumerElement[contextValue]).toBe(2);
@@ -114,13 +112,7 @@ describe('@corpuscule/context', () => {
         public [contextValue]: number;
       }
 
-      const providerElement = new Provider();
-      const consumerElement = new Consumer();
-
-      consumerElement.addParent(providerElement);
-
-      providerElement.connectedCallback();
-      consumerElement.connectedCallback();
+      const [providerElement, consumerElement] = createContextElements(Provider, Consumer);
 
       providerElement[providingValue] = 10;
 
@@ -163,13 +155,7 @@ describe('@corpuscule/context', () => {
         }
       }
 
-      const providerElement = new Provider();
-      const consumerElement = new Consumer();
-
-      consumerElement.addParent(providerElement);
-
-      providerElement.connectedCallback();
-      consumerElement.connectedCallback();
+      const [providerElement, consumerElement] = createContextElements(Provider, Consumer);
 
       providerElement.disconnectedCallback();
       consumerElement.disconnectedCallback();
@@ -196,13 +182,7 @@ describe('@corpuscule/context', () => {
         public [contextValue]: number;
       }
 
-      const providerElement = new Provider();
-      const consumerElement = new Consumer();
-
-      consumerElement.addParent(providerElement);
-
-      providerElement.connectedCallback();
-      consumerElement.connectedCallback();
+      const [providerElement, consumerElement] = createContextElements(Provider, Consumer);
 
       consumerElement.disconnectedCallback();
 
@@ -246,15 +226,9 @@ describe('@corpuscule/context', () => {
         public [contextValue]: number;
       }
 
-      const providerElement = new Provider();
-      const consumerElement = new Consumer();
+      const [providerElement, consumerElement] = createContextElements(Provider, Consumer);
 
-      consumerElement.addParent(providerElement);
-
-      providerElement.connectedCallback();
-      consumerElement.connectedCallback();
-
-      (providerElement as any)[providingValue] = 10;
+      providerElement[providingValue] = 10;
 
       expect(consumerElement[contextValue]).toBe(10);
     });

--- a/packages/context/src/index.js
+++ b/packages/context/src/index.js
@@ -104,7 +104,7 @@ const createContext = (defaultValue) => {
             event.detail.unsubscribe = this[$$unsubscribe];
             event.stopPropagation();
           },
-        }, {isPrivate: true}),
+        }, {isBound: true, isPrivate: true}),
       ],
       kind,
     };

--- a/packages/redux/__tests__/index.ts
+++ b/packages/redux/__tests__/index.ts
@@ -1,10 +1,10 @@
 // tslint:disable:max-classes-per-file
 import {AnyAction, Store} from 'redux';
-// tslint:disable-next-line:no-implicit-dependencies
-import uuid from 'uuid/v4';
-import {BasicConsumer, BasicProvider, defineAndMountContext} from '../../../test/utils';
+import {createMockedContextElements} from '../../../test/mocks/context';
+import {HTMLElementMock} from '../../../test/utils';
 import {
-  connect, connected, dispatcher,
+  connect,
+  connected, dispatcher,
   provider,
   store,
 } from '../src';
@@ -22,145 +22,197 @@ describe('@corpuscule/redux', () => {
     reduxStore.getState.and.callFake(() => reduxState);
   });
 
-  afterEach(() => {
-    document.body.innerHTML = ''; // tslint:disable-line:no-inner-html
-  });
-
-  it('should subscribe to store', () => {
-    @provider
-    class Provider extends BasicProvider {
-      public static is: string = `x-${uuid()}`;
-
-      protected [store]: Store = reduxStore;
-    }
-
-    @connect
-    class Connected extends BasicConsumer {
-      public static is: string = `x-${uuid()}`;
-    }
-
-    defineAndMountContext(Provider, Connected);
-    expect(reduxStore.subscribe).toHaveBeenCalled();
-  });
-
-  it('should allow to declare properties bound with store', () => {
-    @provider
-    class Provider extends BasicProvider {
-      public static is: string = `x-${uuid()}`;
-
-      protected [store]: Store = reduxStore;
-    }
-
-    @connect
-    class Connected extends BasicConsumer {
-      public static is: string = `x-${uuid()}`;
-
-      @connected((state: typeof reduxState) => state.test)
-      public test?: number;
-    }
-
-    const [, c] = defineAndMountContext(Provider, Connected);
-
-    expect(reduxStore.getState).toHaveBeenCalled();
-    expect(c.test).toBe(10);
-  });
-
-  it('should update properties when store is updated', () => {
-    @provider
-    class Provider extends BasicProvider {
-      public static is: string = `x-${uuid()}`;
-
-      protected [store]: Store = reduxStore;
-    }
-
-    @connect
-    class Connected extends BasicConsumer {
-      public static is: string = `x-${uuid()}`;
-
-      @connected((state: typeof reduxState) => state.test)
-      public test?: number;
-    }
-
-    const [, c] = defineAndMountContext(Provider, Connected);
-
-    const [subscription] = reduxStore.subscribe.calls.argsFor(0);
-    reduxState = {test: 20};
-    subscription();
-
-    expect(c.test).toBe(20);
-  });
-
-  it('should unsubscribe from store before subscribing to a new one', () => {
-    @provider
-    class Provider extends BasicProvider {
-      public static is: string = `x-${uuid()}`;
-
-      protected [store]: Store = reduxStore;
-    }
-
-    @connect
-    class Connected extends BasicConsumer {
-      public static is: string = `x-${uuid()}`;
-    }
-
-    const nextStore = jasmine.createSpyObj('nextStore', ['subscribe']);
-
-    const [p] = defineAndMountContext(Provider, Connected);
-
-    expect(unsubscribe).not.toHaveBeenCalled();
-
-    p[store] = nextStore;
-
-    expect(unsubscribe).toHaveBeenCalled();
-    expect(nextStore.subscribe).toHaveBeenCalled();
-  });
-
-  it('should allow to define dispatchers', () => {
-    const externalActionCreator = (arg: number): AnyAction => ({
-      arg,
-      type: 'external',
-    });
-
-    @provider
-    class Provider extends BasicProvider {
-      public static is: string = `x-${uuid()}`;
-
-      protected [store]: Store = reduxStore;
-    }
-
-    @connect
-    class Connected extends BasicConsumer {
-      public static is: string = `x-${uuid()}`;
-
-      @dispatcher
-      public external: typeof externalActionCreator = externalActionCreator;
-
-      private str: string = 'test';
-
-      @dispatcher
-      public test(num: number): AnyAction {
-        return {
-          num,
-          str: this.str,
-          type: 'test',
-        };
+  describe('@connect', () => {
+    it('subscribes to store', () => {
+      @provider
+      class Provider extends HTMLElementMock {
+        public [store]: Store = reduxStore;
       }
-    }
 
-    const [, c] = defineAndMountContext(Provider, Connected);
+      @connect
+      class Connected extends HTMLElementMock {
+      }
 
-    c.external(20);
-    c.test(10);
+      createMockedContextElements(Provider, Connected);
 
-    expect(reduxStore.dispatch).toHaveBeenCalledWith({
-      arg: 20,
-      type: 'external',
+      expect(reduxStore.subscribe).toHaveBeenCalled();
     });
 
-    expect(reduxStore.dispatch).toHaveBeenCalledWith({
-      num: 10,
-      str: 'test',
-      type: 'test',
+    it('unsubscribes from store before subscribing to a new one', () => {
+      @provider
+      class Provider extends HTMLElementMock {
+        public [store]: Store = reduxStore;
+      }
+
+      @connect
+      class Connected extends HTMLElementMock {
+      }
+
+      const nextStore = jasmine.createSpyObj('nextStore', ['subscribe']);
+
+      const [providerElement] = createMockedContextElements(Provider, Connected);
+
+      expect(unsubscribe).not.toHaveBeenCalled();
+
+      providerElement[store] = nextStore;
+
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(nextStore.subscribe).toHaveBeenCalled();
+    });
+
+    it('unsubscribes on disconnect', () => {
+      @provider
+      class Provider extends HTMLElementMock {
+        public [store]: Store = reduxStore;
+      }
+
+      @connect
+      class Connected extends HTMLElementMock {
+      }
+
+      const [, connectedElement] = createMockedContextElements(Provider, Connected);
+
+      connectedElement.disconnectedCallback();
+
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+
+    describe('@connected', () => {
+      it('allows to declare properties connected with store', () => {
+        @provider
+        class Provider extends HTMLElementMock {
+          public [store]: Store = reduxStore;
+        }
+
+        @connect
+        class Connected extends HTMLElementMock {
+          @connected((state: typeof reduxState) => state.test)
+          public test?: number;
+        }
+
+        const [, connectedElement] = createMockedContextElements(Provider, Connected);
+
+        expect(reduxStore.getState).toHaveBeenCalled();
+        expect(connectedElement.test).toBe(10);
+      });
+
+      it('updates properties when store is updated', () => {
+        @provider
+        class Provider extends HTMLElementMock {
+          public [store]: Store = reduxStore;
+        }
+
+        @connect
+        class Connected extends HTMLElementMock {
+          @connected((state: typeof reduxState) => state.test)
+          public test?: number;
+        }
+
+        const [, connectedElement] = createMockedContextElements(Provider, Connected);
+
+        const [subscription] = reduxStore.subscribe.calls.argsFor(0);
+        reduxState = {test: 20};
+        subscription();
+
+        expect(connectedElement.test).toBe(20);
+      });
+
+      it('avoids property update if new value is equal to old one', () => {
+        const setterSpy = jasmine.createSpy('setter');
+
+        @provider
+        class Provider extends HTMLElementMock {
+          public [store]: Store = reduxStore;
+        }
+
+        @connect
+        class Connected extends HTMLElementMock {
+          public testValue: number = 10;
+
+          @connected((state: typeof reduxState) => state.test)
+          public get test(): number {
+            return this.testValue;
+          }
+
+          public set test(value: number) {
+            setterSpy();
+            this.testValue = value;
+          }
+        }
+
+        createMockedContextElements(Provider, Connected);
+
+        const [subscription] = reduxStore.subscribe.calls.argsFor(0);
+        reduxState = {test: 10};
+        subscription();
+
+        expect(setterSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('@dispatcher', () => {
+    it('allows to define dispatchers', () => {
+      const externalActionCreator = (arg: number): AnyAction => ({
+        arg,
+        type: 'external',
+      });
+
+      @provider
+      class Provider extends HTMLElementMock {
+        public [store]: Store = reduxStore;
+      }
+
+      @connect
+      class Connected extends HTMLElementMock {
+        @dispatcher
+        public external: typeof externalActionCreator = externalActionCreator;
+
+        private str: string = 'test';
+
+        @dispatcher
+        public test(num: number): AnyAction {
+          return {
+            num,
+            str: this.str,
+            type: 'test',
+          };
+        }
+      }
+
+      const [, connectedElement] = createMockedContextElements(Provider, Connected);
+
+      connectedElement.external(20);
+      connectedElement.test(10);
+
+      expect(reduxStore.dispatch).toHaveBeenCalledWith({
+        arg: 20,
+        type: 'external',
+      });
+
+      expect(reduxStore.dispatch).toHaveBeenCalledWith({
+        num: 10,
+        str: 'test',
+        type: 'test',
+      });
+    });
+
+    it('throws an error if dispatcher property is not a method or assigned function', () => {
+      expect(() => {
+        // @ts-ignore
+        class Connected extends HTMLElementMock {
+          @dispatcher
+          public external: number = 1;
+        }
+      }).toThrow(new TypeError('@dispatcher: "external" should be initialized with a function'));
+
+      expect(() => {
+        // @ts-ignore
+        class Connected extends HTMLElementMock {
+          @dispatcher
+          public nothing?: unknown;
+        }
+      }).toThrow(new TypeError('@dispatcher: "nothing" should be initialized with a function'));
     });
   });
 });

--- a/packages/redux/src/decorators.js
+++ b/packages/redux/src/decorators.js
@@ -6,7 +6,14 @@ import {context as $$context} from './tokens/internal';
 export const connectedRegistry = new WeakMap();
 
 export const connected = getter => (descriptor) => {
-  assertKind('connected', 'field', descriptor.kind);
+  const {
+    descriptor: {get, set},
+    kind,
+  } = descriptor;
+
+  assertKind('connected', 'field or accessor', kind, {
+    correct: kind === 'field' || (kind === 'method' && get && set), // eslint-disable-line no-extra-parens
+  });
 
   return {
     ...descriptor,
@@ -34,13 +41,13 @@ export const dispatcher = ({
     const initialized = initializer ? initializer() : undefined;
 
     if (!initialized || typeof initialized !== 'function') {
-      throw new Error(`@dispatcher: "${key}" should be initialized with a function`);
+      throw new TypeError(`@dispatcher: "${key}" should be initialized with a function`);
     }
 
     return method({
       key,
       value(...args) {
-        this[$$context].dispatch(initialized.apply(this, args));
+        this[$$context].dispatch(initialized(...args));
       },
     }, {isBound: true});
   }

--- a/packages/router/src/index.d.ts
+++ b/packages/router/src/index.d.ts
@@ -21,9 +21,8 @@ export const provider: ReturnType<typeof createContext>['provider'];
 export const router: unique symbol;
 
 export interface RouterOutlet<T> {
-  readonly routeResolving: Promise<void>;
   readonly [layout]: T;
-  [resolve](path: string): IterableIterator<any>;
+  [resolve]?(path: string): IterableIterator<any>;
 }
 
 export const outlet: (routes: ReadonlyArray<Route>) => ClassDecorator;

--- a/test/mocks/context.ts
+++ b/test/mocks/context.ts
@@ -1,0 +1,63 @@
+// tslint:disable:no-invalid-this
+import {Constructor, HTMLElementMock} from '../utils';
+
+export const context = jasmine.createSpyObj('context', [
+  'consumer',
+  'provider',
+]);
+
+context.providingValue = Symbol('providingValue');
+context.contextValue = Symbol('consumingValue');
+
+const identity = <T>(descriptor: T) => descriptor;
+
+context.consumer.and.callFake(identity);
+context.provider.and.callFake(identity);
+
+const createContext = jasmine.createSpy('createContext');
+createContext.and.returnValue(context);
+
+export default createContext;
+
+export const createMockedContextElements = <T extends HTMLElementMock, U extends HTMLElementMock>(
+  providerConstructor: Constructor<T>,
+  consumerConstructor: Constructor<U>,
+  consumerNumber: number = 1,
+) => {
+  const consumers = new Array(consumerNumber);
+  const provider = new providerConstructor();
+
+  for (let i = 0; i < consumerNumber; i++) { // tslint:disable-line:no-increment-decrement
+    consumers[i] = new consumerConstructor();
+    consumers[i][context.contextValue] = (provider as any)[context.providingValue];
+  }
+
+  const storage = Symbol();
+
+  Object.defineProperties(provider, {
+    [storage]: {
+      value: (provider as any)[context.providingValue],
+      writable: true,
+    },
+    [context.providingValue]: {
+      get(this: any): unknown {
+        return this[storage];
+      },
+      set(this: any, value: unknown): void {
+        this[storage] = value;
+
+        for (const consumer of consumers) {
+          (consumer as any)[context.contextValue] = value;
+        }
+      },
+    },
+  });
+
+  provider.connectedCallback();
+
+  for (const consumer of consumers) {
+    consumer.connectedCallback();
+  }
+
+  return [provider, ...consumers];
+};

--- a/test/mocks/context.ts
+++ b/test/mocks/context.ts
@@ -19,16 +19,15 @@ createContext.and.returnValue(context);
 
 export default createContext;
 
-export const createMockedContextElements = <T extends HTMLElementMock, U extends HTMLElementMock>(
-  providerConstructor: Constructor<T>,
-  consumerConstructor: Constructor<U>,
-  consumerNumber: number = 1,
-) => {
-  const consumers = new Array(consumerNumber);
+export const createMockedContextElements = <T extends HTMLElementMock[]>(
+  ...constructors: {[K in keyof T]: Constructor<T[K]>}
+): T => {
+  const [providerConstructor, ...consumerConstructors] = constructors;
+  const consumers = new Array(consumerConstructors.length);
   const provider = new providerConstructor();
 
-  for (let i = 0; i < consumerNumber; i++) { // tslint:disable-line:no-increment-decrement
-    consumers[i] = new consumerConstructor();
+  for (let i = 0; i < consumerConstructors.length; i++) { // tslint:disable-line:no-increment-decrement
+    consumers[i] = new consumerConstructors[i]();
     consumers[i][context.contextValue] = (provider as any)[context.providingValue];
   }
 
@@ -59,5 +58,5 @@ export const createMockedContextElements = <T extends HTMLElementMock, U extends
     consumer.connectedCallback();
   }
 
-  return [provider, ...consumers];
+  return [provider, ...consumers] as T;
 };

--- a/test/utils.d.ts
+++ b/test/utils.d.ts
@@ -1,5 +1,4 @@
 // tslint:disable:max-classes-per-file
-
 export interface Constructor<T> {
   new(...args: any[]): T; // tslint:disable-line:readonly-array
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -93,7 +93,13 @@ export class HTMLElementMock {
 
   dispatchEvent(event) {
     for (const {listeners} of this.nestingChain) {
-      for (const listener of listeners.get(event.type)) {
+      const list = listeners.get(event.type);
+
+      if (!list) {
+        continue;
+      }
+
+      for (const listener of list) {
         listener(event);
       }
     }

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -1,8 +1,13 @@
 /* eslint-disable sort-keys */
+const {resolve} = require('path');
+
 module.exports = {
   devtool: 'inline-source-map',
   mode: 'development',
   resolve: {
+    alias: {
+      '@corpuscule/context': resolve(__dirname, './mocks/context'),
+    },
     extensions: [
       '.js',
       '.ts',


### PR DESCRIPTION
Currently tests are based on the browser system which limits possible checks due to system restrictions. This PR changes tests to work with mocks which allows to remove these restrictions and get more coverage.