### PR TITLE
Refactor element private properties to avoid privates leaking and allow inheritance

### DIFF
--- a/packages/element/src/decorators/element.js
+++ b/packages/element/src/decorators/element.js
@@ -12,12 +12,6 @@ import {
   scheduler as $scheduler,
   internalChangedCallback as $internalChangedCallback,
 } from '../tokens/lifecycle';
-import {
-  connected as $$connected,
-  invalidate as $$invalidate,
-  root as $$root,
-  valid as $$valid,
-} from '../tokens/internal';
 import {field, method} from '@corpuscule/utils/lib/descriptors';
 
 const attributeChangedCallbackKey = 'attributeChangedCallback';
@@ -54,6 +48,11 @@ const element = name => ({kind, elements}) => {
   if (!elements.find(({key}) => key === $render)) {
     throw new Error('[render]() is not implemented');
   }
+
+  const $$connected = Symbol();
+  const $$invalidate = Symbol();
+  const $$root = Symbol();
+  const $$valid = Symbol();
 
   const [
     superAttributeChangedCallback,

--- a/packages/element/src/decorators/element.js
+++ b/packages/element/src/decorators/element.js
@@ -1,30 +1,23 @@
 /* eslint-disable no-invalid-this, prefer-arrow-callback */
 import {assertKind} from '@corpuscule/utils/lib/asserts';
 import getSuperMethods from '@corpuscule/utils/lib/getSuperMethods';
-import {render as renderer} from 'lit-html';
-import scheduler from '../scheduler';
+import {field, lifecycleKeys, method} from '@corpuscule/utils/lib/descriptors';
+import {render as defaultRenderer} from 'lit-html';
+import defaultScheduler from '../scheduler';
 import {
   createRoot as $createRoot,
   updatedCallback as $updatedCallback,
   propertyChangedCallback as $propertyChangedCallback,
   render as $render,
-  renderer as $renderer,
-  scheduler as $scheduler,
   internalChangedCallback as $internalChangedCallback,
 } from '../tokens/lifecycle';
-import {field, method} from '@corpuscule/utils/lib/descriptors';
 
 const attributeChangedCallbackKey = 'attributeChangedCallback';
-const connectedCallbackKey = 'connectedCallback';
+const [connectedCallbackKey] = lifecycleKeys;
 const isCorpusculeElementKey = 'isCorpusculeElement';
 
 // eslint-disable-next-line no-empty-function
 const noop = () => {};
-
-const fields = [
-  $renderer,
-  $scheduler,
-];
 
 const methods = [
   attributeChangedCallbackKey,
@@ -38,21 +31,49 @@ const methods = [
 const filteringNames = [
   'is',
   isCorpusculeElementKey,
-  ...fields,
   ...methods,
 ];
 
-const element = name => ({kind, elements}) => {
+const connectedMap = new WeakMap();
+const rendererMap = new WeakMap();
+const rootMap = new WeakMap();
+const schedulerMap = new WeakMap();
+const validMap = new WeakMap();
+
+const invalidate = (self) => {
+  if (!validMap.get(self)) {
+    return;
+  }
+
+  validMap.set(self, false);
+
+  schedulerMap.get(self.constructor)(() => {
+    const rendered = self[$render]();
+
+    if (rendered) {
+      rendererMap.get(self.constructor)(rendered, rootMap.get(self), {eventContext: self});
+    }
+
+    const shouldRunUpdatedCallback = connectedMap.get(self);
+
+    connectedMap.set(self, true);
+    validMap.set(self, true);
+
+    if (shouldRunUpdatedCallback) {
+      self[$updatedCallback]();
+    }
+  });
+};
+
+const element = (
+  name,
+  {renderer = defaultRenderer, scheduler = defaultScheduler} = {},
+) => ({kind, elements}) => {
   assertKind('element', 'class', kind);
 
   if (!elements.find(({key}) => key === $render)) {
     throw new Error('[render]() is not implemented');
   }
-
-  const $$connected = Symbol();
-  const $$invalidate = Symbol();
-  const $$root = Symbol();
-  const $$valid = Symbol();
 
   const [
     superAttributeChangedCallback,
@@ -68,11 +89,6 @@ const element = name => ({kind, elements}) => {
     [$updatedCallback]: noop,
   });
 
-  const [
-    {initializer: existingRenderer = () => renderer} = {},
-    {initializer: existingScheduler = () => scheduler} = {},
-  ] = fields.map(fieldName => elements.find(({key}) => key === fieldName));
-
   return {
     elements: [
       ...elements.filter(({key}) => !filteringNames.includes(key)),
@@ -86,32 +102,24 @@ const element = name => ({kind, elements}) => {
         initializer: () => true,
         key: isCorpusculeElementKey,
       }, {isReadonly: true, isStatic: true}),
-      field({
-        initializer: existingRenderer,
-        key: $renderer,
-      }, {isReadonly: true, isStatic: true}),
-      field({
-        initializer: existingScheduler,
-        key: $scheduler,
-      }, {isReadonly: true, isStatic: true}),
 
       // Public
       method({
         key: connectedCallbackKey,
         value() {
           superConnectedCallback.call(this);
-          this[$$invalidate]();
+          invalidate(this);
         },
       }),
       method({
         key: attributeChangedCallbackKey,
         value(attributeName, oldValue, newValue) {
-          if (oldValue === newValue || !this[$$connected]) {
+          if (oldValue === newValue || !connectedMap.get(this)) {
             return;
           }
 
           superAttributeChangedCallback.call(this, attributeName, oldValue, newValue);
-          this[$$invalidate]();
+          invalidate(this);
         },
       }),
 
@@ -123,23 +131,23 @@ const element = name => ({kind, elements}) => {
       method({
         key: $internalChangedCallback,
         value(internalName, oldValue, newValue) {
-          if (!this[$$connected]) {
+          if (!connectedMap.get(this)) {
             return;
           }
 
           superInternalChangedCallback.call(this, internalName, oldValue, newValue);
-          this[$$invalidate]();
+          invalidate(this);
         },
       }),
       method({
         key: $propertyChangedCallback,
         value(propertyName, oldValue, newValue) {
-          if (oldValue === newValue || !this[$$connected]) {
+          if (oldValue === newValue || !connectedMap.get(this)) {
             return;
           }
 
           superPropertyChangedCallback.call(this, propertyName, oldValue, newValue);
-          this[$$invalidate]();
+          invalidate(this);
         },
       }),
       method({
@@ -147,56 +155,19 @@ const element = name => ({kind, elements}) => {
         value: superUpdatedCallback,
       }),
 
-      // Private
-      field({
-        initializer: () => false,
-        key: $$connected,
-      }, {isPrivate: true}),
-      field({
-        initializer: () => true,
-        key: $$valid,
-      }, {isPrivate: true}),
+      // Initializer
       field({
         initializer() {
-          return this[$createRoot]();
+          connectedMap.set(this, false);
+          rootMap.set(this, this[$createRoot]());
+          validMap.set(this, true);
         },
-        key: $$root,
-      }, {isPrivate: true}),
-      method({
-        key: $$invalidate,
-        value() {
-          if (!this[$$valid]) {
-            return;
-          }
-
-          const {
-            [$renderer]: render,
-            [$scheduler]: schedule,
-          } = this.constructor;
-
-          this[$$valid] = false;
-
-          schedule(() => {
-            const rendered = this[$render]();
-
-            if (rendered) {
-              render(rendered, this[$$root], {eventContext: this});
-            }
-
-            const shouldRunUpdatedCallback = this[$$connected];
-
-            this[$$connected] = true;
-            this[$$valid] = true;
-
-            if (shouldRunUpdatedCallback) {
-              this[$updatedCallback]();
-            }
-          });
-        },
-      }, {isPrivate: true}),
+      }),
     ],
     finisher(target) {
       customElements.define(name, target);
+      rendererMap.set(target, renderer);
+      schedulerMap.set(target, scheduler);
     },
     kind,
   };

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -6,14 +6,16 @@ export interface ComputingPair {
   readonly observer: PropertyDecorator;
 }
 
-export type ElementRenderer = typeof litHtmlRender;
-export type ElementScheduler = (callback: () => void) => Promise<void>;
+export interface ElementOptions {
+  readonly renderer?: typeof litHtmlRender;
+  readonly scheduler?: (callback: () => void) => Promise<void>;
+}
 
 export type AttributeGuard = BooleanConstructor | NumberConstructor | StringConstructor;
 export type PropertyGuard = (value: unknown) => boolean;
 
 export const attribute: (attributeName: string, guard: AttributeGuard) => PropertyDecorator;
-export const element: (name: string) => ClassDecorator;
+export const element: (name: string, options?: ElementOptions) => ClassDecorator;
 export const internal: PropertyDecorator;
 export const property: (guard?: PropertyGuard) => PropertyDecorator;
 
@@ -23,8 +25,6 @@ export const createRoot: unique symbol;
 export const internalChangedCallback: unique symbol;
 export const propertyChangedCallback: unique symbol;
 export const render: unique symbol;
-export const renderer: unique symbol;
-export const scheduler: unique symbol;
 export const updatedCallback: unique symbol;
 
 export class UnsafeStatic {

--- a/packages/element/src/tokens/internal.js
+++ b/packages/element/src/tokens/internal.js
@@ -1,4 +1,0 @@
-export const connected = Symbol();
-export const invalidate = Symbol();
-export const root = Symbol();
-export const valid = Symbol();

--- a/packages/redux/src/decorators.js
+++ b/packages/redux/src/decorators.js
@@ -1,7 +1,7 @@
 import addToRegistry from '@corpuscule/utils/lib/addToRegistry';
 import {assertKind, assertPlacement} from '@corpuscule/utils/lib/asserts';
 import {method} from '@corpuscule/utils/lib/descriptors';
-import {context as $$context} from './tokens/internal';
+import {contextMap} from './utils';
 
 export const connectedRegistry = new WeakMap();
 
@@ -47,7 +47,8 @@ export const dispatcher = ({
     return method({
       key,
       value(...args) {
-        this[$$context].dispatch(initialized(...args));
+        this[contextMap.get(this.constructor)]
+          .dispatch(initialized(...args));
       },
     }, {isBound: true});
   }
@@ -58,7 +59,8 @@ export const dispatcher = ({
       method({
         key,
         value(...args) {
-          this[$$context].dispatch(descriptor.value.apply(this, args));
+          this[contextMap.get(this.constructor)]
+            .dispatch(descriptor.value.apply(this, args));
         },
       }, {isBound: true}),
     ],

--- a/packages/redux/src/index.js
+++ b/packages/redux/src/index.js
@@ -2,13 +2,8 @@ import createContext from '@corpuscule/context';
 import {assertKind} from '@corpuscule/utils/lib/asserts';
 import {accessor, method} from '@corpuscule/utils/lib/descriptors';
 import getSuperMethods from '@corpuscule/utils/lib/getSuperMethods';
-import {
-  context as $$context,
-  subscribe as $$subscribe,
-  unsubscribe as $$unsubscribe,
-  update as $$update,
-} from './tokens/internal';
 import {connectedRegistry} from './decorators';
+import {contextMap} from './utils';
 
 const {
   consumer,
@@ -33,6 +28,12 @@ export const connect = (classDescriptor) => {
   assertKind('connect', 'class', classDescriptor.kind);
 
   const {elements, kind} = consumer(classDescriptor);
+
+  const $$context = Symbol();
+  const $$subscribe = Symbol();
+  const $$unsubscribe = Symbol();
+  const $$update = Symbol();
+
   const [superDisconnectedCallback] = getSuperMethods(elements, [disconnectedCallbackKey]);
 
   return {
@@ -95,6 +96,9 @@ export const connect = (classDescriptor) => {
         },
       }, {isPrivate: true}),
     ],
+    finisher(target) {
+      contextMap.set(target, $$context);
+    },
     kind,
   };
 };

--- a/packages/redux/src/tokens/internal.js
+++ b/packages/redux/src/tokens/internal.js
@@ -1,4 +1,0 @@
-export const context = Symbol();
-export const subscribe = Symbol();
-export const unsubscribe = Symbol();
-export const update = Symbol();

--- a/packages/redux/src/utils.js
+++ b/packages/redux/src/utils.js
@@ -1,0 +1,1 @@
+export const contextMap = new WeakMap();

--- a/packages/router/src/Link.js
+++ b/packages/router/src/Link.js
@@ -1,5 +1,6 @@
 import push from './push';
-import {handleClick as $$handleClick} from './tokens/internal';
+
+const $$handleClick = Symbol();
 
 export default class Link extends HTMLAnchorElement {
   static get is() {

--- a/packages/router/src/outlet.js
+++ b/packages/router/src/outlet.js
@@ -2,9 +2,6 @@ import createContext from '@corpuscule/context';
 import {assertKind} from '@corpuscule/utils/lib/asserts';
 import {lifecycleKeys, method} from '@corpuscule/utils/lib/descriptors';
 import getSuperMethods from '@corpuscule/utils/lib/getSuperMethods';
-import {
-  updateRoute as $$updateRoute,
-} from './tokens/internal';
 import {layout, resolve} from './tokens/lifecycle';
 
 const {
@@ -35,6 +32,8 @@ const outlet = routes => (classDescriptor) => {
   assertKind('outlet', 'class', classDescriptor.kind);
 
   const {elements, kind} = consumer(classDescriptor);
+
+  const $$updateRoute = Symbol();
 
   const [
     superConnectedCallback,

--- a/packages/router/src/tokens/internal.js
+++ b/packages/router/src/tokens/internal.js
@@ -1,3 +1,0 @@
-export const handleClick = Symbol();
-export const resolving = Symbol();
-export const updateRoute = Symbol();

--- a/packages/utils/__tests__/getSuperMethods.ts
+++ b/packages/utils/__tests__/getSuperMethods.ts
@@ -90,6 +90,31 @@ const testGetSuperMethod = () => {
       superMethod();
       expect(methodSpy).toHaveBeenCalled();
     });
+
+    it('works correctly if super method created for several classes in inheritance chain', () => {
+      const methodSpy = jasmine.createSpy('method');
+
+      const [superMethod] = getSuperMethods([], ['method']);
+
+      class PreBasic {
+        public method(): void {
+          methodSpy();
+        }
+      }
+
+      class Basic extends PreBasic {
+        public method(): void {
+          superMethod.call(this);
+        }
+      }
+
+      class Test extends Basic {}
+
+      const test = new Test();
+
+      superMethod.call(test);
+      expect(methodSpy).toHaveBeenCalled();
+    });
   });
 };
 

--- a/packages/utils/src/getSuperMethods.js
+++ b/packages/utils/src/getSuperMethods.js
@@ -10,7 +10,7 @@ const getSuperMethods = (elements, names, defaults = {}) => names.map((name) => 
         const superClass = Object.getPrototypeOf(this.constructor.prototype);
 
         if (superClass && typeof superClass[name] === 'function') {
-          return superClass[name].apply(this, args);
+          return superClass[name](...args);
         }
       }
 


### PR DESCRIPTION
This PR introduces two major fixes:

1. It makes all private properties truly private, in other words, forces them to regenerate on each call of decorator. This change was made following [this discussion](https://github.com/tc39/proposal-decorators/issues/167#issuecomment-439990694) to avoid leaking private properties.
2. It changes internal mechanism of `@element` decorator to allow elements inheritance. 

Let's talk a bit more about second improvement. `@element` adds a lot of private properties to an element, and by default they works as expected. But what happen if we inherit this element and add `@element` decorator to it again? Correct, all properties will be duplicated, but won't be overridden because of the first improvement done in this PR. Just because another `Symbol` (or another PrivateName) is generated for each element.

And problems start when user calls `super.connectedCallback()` from the child's `connectedCallback`. Both parent and child elements' `connectedCallback` calls `[invalidate]()` internally, but each one calls its own property. So instead of having rendering once we have it twice. And this number will increase if we add another element of prototype chain. 

That's why this PR solves this problem making private properties and `[invalidate]()` method depending on `this` which is same for parent and child element. 