### PR TITLE
Customized built-in elements

### DIFF
--- a/packages/element/__tests__/decorators/attribute.ts
+++ b/packages/element/__tests__/decorators/attribute.ts
@@ -1,28 +1,29 @@
 // tslint:disable:max-classes-per-file
-import {HTMLElementMock} from '../../../../test/utils';
+import {CustomElement, genName} from '../../../../test/utils';
 import {attribute} from '../../src';
 
 const testAttributeDecorator = () => {
   describe('@attribute', () => {
     it('gets string attribute', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
-        public readonly attributes: Map<string, string> = new Map([['attr', 'str']]);
 
         @attribute('attr', String)
         public attribute: string | null = null;
       }
 
+      customElements.define(genName(), Test);
+
       const test = new Test();
+      test.setAttribute('attr', 'str');
       test.connectedCallback();
 
       expect(test.attribute).toBe('str');
     });
 
     it('properly gets boolean attribute', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
-        public readonly attributes: Map<string, string> = new Map([['a1', '']]);
 
         @attribute('a1', Boolean)
         public attr1: boolean | null = null;
@@ -31,7 +32,10 @@ const testAttributeDecorator = () => {
         public attr2: boolean | null = null;
       }
 
+      customElements.define(genName(), Test);
+
       const test = new Test();
+      test.setAttribute('a1', '');
       test.connectedCallback();
 
       expect(test.attr1).toBeTruthy();
@@ -39,41 +43,43 @@ const testAttributeDecorator = () => {
     });
 
     it('properly gets number attributes', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
-        public readonly attributes: Map<string, string> = new Map([['num', '10']]);
 
         @attribute('num', Number)
         public numAttribute: number | null = null;
       }
 
+      customElements.define(genName(), Test);
+
       const test = new Test();
+      test.setAttribute('num', '10');
       test.connectedCallback();
 
       expect(test.numAttribute).toBe(10);
     });
 
     it('sets string attribute', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
 
         @attribute('attr', String)
         public attribute: string | null = null;
       }
 
+      customElements.define(genName(), Test);
+
       const test = new Test();
       test.connectedCallback();
 
       test.attribute = 'str';
 
-      expect(test.attributes).toEqual(new Map([['attr', 'str']]));
+      expect(test.getAttribute('attr')).toBe('str');
     });
 
     it('properly sets boolean attributes', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
-
-        public readonly attributes: Map<string, string> = new Map([['a2', '']]);
 
         @attribute('a1', Boolean)
         public attr1: boolean | null = null;
@@ -82,33 +88,39 @@ const testAttributeDecorator = () => {
         public attr2: boolean | null = null;
       }
 
+      customElements.define(genName(), Test);
+
       const test = new Test();
+      test.setAttribute('a2', '');
       test.connectedCallback();
 
       test.attr1 = true;
       test.attr2 = false;
 
-      expect(test.attributes).toEqual(new Map([['a1', '']]));
+      expect(test.getAttribute('a1')).toBe('');
+      expect(test.hasAttribute('a2')).toBeFalsy();
     });
 
     it('properly sets number attribute', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
 
         @attribute('num', Number)
         public numAttribute: number | null = null;
       }
 
+      customElements.define(genName(), Test);
+
       const test = new Test();
       test.connectedCallback();
 
       test.numAttribute = 10;
 
-      expect(test.attributes).toEqual(new Map([['num', '10']]));
+      expect(test.getAttribute('num')).toBe('10');
     });
 
     it('initializes and fills "observedAttributes"', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
 
         @attribute('a1', Boolean)
@@ -118,22 +130,30 @@ const testAttributeDecorator = () => {
         public attr2: string | null = null;
       }
 
+      customElements.define(genName(), Test);
+
       expect(Test.observedAttributes).toEqual(['a1', 'a2']);
     });
 
     it('runs "attributeChangedCallback" on change', () => {
       const attributeChangedCallbackSpy = jasmine.createSpy('onAttributeChange');
 
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
 
         @attribute('attr', String)
         public attribute: string | null = null;
 
-        public attributeChangedCallback(...args: Array<unknown>): void {
-          attributeChangedCallbackSpy(...args);
+        public attributeChangedCallback(
+          attributeName: string,
+          oldValue: string,
+          newValue: string,
+        ): void {
+          attributeChangedCallbackSpy(attributeName, oldValue, newValue);
         }
       }
+
+      customElements.define(genName(), Test);
 
       const test = new Test();
 
@@ -154,12 +174,14 @@ const testAttributeDecorator = () => {
     });
 
     it('throws an error if value does not fit guard', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
 
         @attribute('num', Number)
         public numAttribute: number | null = null;
       }
+
+      customElements.define(genName(), Test);
 
       const test = new Test();
       test.connectedCallback();
@@ -170,12 +192,14 @@ const testAttributeDecorator = () => {
     });
 
     it('gets null if no attribute exist', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
 
         @attribute('num', Number)
         public numAttribute: number | null = null;
       }
+
+      customElements.define(genName(), Test);
 
       const test = new Test();
       test.connectedCallback();
@@ -184,7 +208,7 @@ const testAttributeDecorator = () => {
     });
 
     it('accepts both null and undefined as a value of attribute', () => {
-      class Test extends HTMLElementMock {
+      class Test extends CustomElement {
         public static readonly observedAttributes: ReadonlyArray<string> = [];
 
         @attribute('a1', Number)
@@ -193,6 +217,8 @@ const testAttributeDecorator = () => {
         @attribute('a2', Number)
         public a2?: number | null = 20;
       }
+
+      customElements.define(genName(), Test);
 
       const test = new Test();
 

--- a/packages/element/__tests__/decorators/element.ts
+++ b/packages/element/__tests__/decorators/element.ts
@@ -230,11 +230,7 @@ const testElementDecorator = () => {
       const [renderCallback] = schedulerSpy.calls.mostRecent().args;
       renderCallback();
 
-      expect(rendererSpy).toHaveBeenCalledWith(
-        'rendered string',
-        jasmine.any(Node),
-        test,
-      );
+      expect(rendererSpy).toHaveBeenCalledWith('rendered string', jasmine.any(Node), test);
     });
 
     it('does not allow to run re-render if old and new values are identical (except for internal)', () => {
@@ -430,6 +426,43 @@ const testElementDecorator = () => {
         expect(connectedSpyChild).toHaveBeenCalled();
         expect(connectedSpyParent).toHaveBeenCalled();
       });
+
+      it('allows to override [createRoot] method', () => {
+        const parentContainer = document.createElement('div');
+        const childContainer = document.createElement('div');
+
+        @element(genName())
+        class Parent extends CustomElement {
+          public [createRoot](): HTMLElement {
+            return parentContainer;
+          }
+
+          public [render](): null {
+            return null;
+          }
+        }
+
+        @element(genName())
+        // @ts-ignore
+        class Child extends Parent {
+          public [createRoot](): HTMLElement {
+            return childContainer;
+          }
+
+          public [render](): null {
+            return null;
+          }
+        }
+
+        const child = new Child();
+        child.connectedCallback();
+
+        const [renderCallback] = schedulerSpy.calls.mostRecent().args;
+        renderCallback();
+
+        expect(rendererSpy).toHaveBeenCalledWith(null, childContainer, child);
+      });
+    });
 
     describe('customized built-in elements', () => {
       it('allows to create', () => {

--- a/packages/element/__tests__/decorators/element.ts
+++ b/packages/element/__tests__/decorators/element.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-unnecessary-class max-classes-per-file no-unbound-method no-empty
-import {createTestingPromise, genName} from '../../../../test/utils';
+import {createTestingPromise, CustomElement, genName} from '../../../../test/utils';
 import {
   createRoot,
   element as basicElement,
@@ -8,18 +8,6 @@ import {
   render,
   updatedCallback,
 } from '../../src';
-
-class CustomElement extends HTMLElement {
-  public attributeChangedCallback(
-    _attributeName: string,
-    _oldValue: string,
-    _newValue: string,
-  ): void {}
-
-  public connectedCallback(): void {}
-
-  public disconnectedCallback(): void {}
-}
 
 const testElementDecorator = () => {
   describe('@element', () => {

--- a/packages/element/src/decorators/element.js
+++ b/packages/element/src/decorators/element.js
@@ -19,6 +19,8 @@ const noop = () => {};
 
 const filteringNames = ['is', 'observedAttributes'];
 
+const rootProperty = new WeakMap();
+
 const element = (name, {extends: builtin, renderer, scheduler = defaultScheduler}) => ({
   kind,
   elements,
@@ -37,7 +39,6 @@ const element = (name, {extends: builtin, renderer, scheduler = defaultScheduler
 
   const $$connected = Symbol();
   const $$invalidate = Symbol();
-  const $$root = Symbol();
   const $$valid = Symbol();
 
   const $$superAttributeChangedCallback = Symbol();
@@ -157,9 +158,10 @@ const element = (name, {extends: builtin, renderer, scheduler = defaultScheduler
       }),
       field({
         initializer() {
-          return this[$createRoot]();
+          if (!rootProperty.has(this)) {
+            rootProperty.set(this, this[$createRoot]());
+          }
         },
-        key: $$root,
       }),
       field({
         initializer: () => true,
@@ -179,7 +181,7 @@ const element = (name, {extends: builtin, renderer, scheduler = defaultScheduler
               const isConnecting = !this[$$connected];
 
               await scheduler(() => {
-                renderer(this[$render](), this[$$root], this);
+                renderer(this[$render](), rootProperty.get(this), this);
                 this[$$connected] = true;
                 this[$$valid] = true;
               });

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -5,6 +5,7 @@ export interface ComputingPair {
 }
 
 export interface ElementDecoratorParams {
+  readonly extends?: keyof HTMLElementTagNameMap;
   readonly renderer: (
     result: unknown,
     container: Element | DocumentFragment,

--- a/packages/utils/__tests__/descriptors.ts
+++ b/packages/utils/__tests__/descriptors.ts
@@ -88,6 +88,7 @@ const testDescriptors = () => {
           descriptor: {
             configurable: true,
             value,
+            writable: true,
           },
           extras,
           finisher,

--- a/packages/utils/src/descriptors.js
+++ b/packages/utils/src/descriptors.js
@@ -36,7 +36,7 @@ export const method = (
   }
 
   return {
-    descriptor: {configurable: true, value},
+    descriptor: {configurable: true, value, writable: true},
     extras,
     finisher,
     key,

--- a/test/utils.d.ts
+++ b/test/utils.d.ts
@@ -31,6 +31,18 @@ export class HTMLElementMock {
   public disconnectedCallback(): void;
 }
 
+export class CustomElement extends HTMLElement {
+  public attributeChangedCallback(
+    key: PropertyKey,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void;
+
+  public connectedCallback(): void;
+
+  public disconnectedCallback(): void;
+}
+
 export const genName: () => string;
 
 export const createTestingPromise: () => [Promise<void>, () => void];

--- a/test/utils.d.ts
+++ b/test/utils.d.ts
@@ -31,4 +31,6 @@ export class HTMLElementMock {
   public disconnectedCallback(): void;
 }
 
+export const genName: () => string;
+
 export const createTestingPromise: () => [Promise<void>, () => void];

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,4 @@
-/* eslint-disable class-methods-use-this, no-empty-function */
+/* eslint-disable class-methods-use-this, max-classes-per-file, no-empty-function */
 export class HTMLElementMock {
   constructor() {
     this.attributes = new Map();
@@ -66,6 +66,14 @@ export class HTMLElementMock {
     );
     this.attributes.set(key, v);
   }
+}
+
+export class CustomElement extends HTMLElement {
+  attributeChangedCallback() {}
+
+  connectedCallback() {}
+
+  disconnectedCallback() {}
 }
 
 export const genName = () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -68,6 +68,13 @@ export class HTMLElementMock {
   }
 }
 
+export const genName = () => {
+  const arr = new Uint32Array(2);
+  const [rnd1, rnd2] = crypto.getRandomValues(arr);
+
+  return `x-${rnd1}${rnd2}`;
+};
+
 export const createTestingPromise = () => {
   let resolve;
   const promise = new Promise(r => {


### PR DESCRIPTION
This PR introduces support for [customized built-in elements](https://developers.google.com/web/fundamentals/web-components/customelements#extendhtml) which previous implementation lacks. 

Also there is couple improvements:
* Use `HTMLElement` instead of `HTMLElementMock` for `@corpuscule/element` to improve testability.
* Fix behavior of `[createRoot]` method with inheritance.