### PR TITLE
Form: add handling change events of default HTML elements

### DIFF
--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -505,6 +505,171 @@ const testField = () => {
         expect(state.focus).toHaveBeenCalled();
       });
     });
+
+    describe('default fields', () => {
+      let fieldElement: HTMLElement;
+
+      beforeEach(() => {
+        @form()
+        class Form extends CustomElement {}
+
+        @field({scheduler})
+        class FormField extends CustomElement implements Field<object> {
+          public readonly [formApi]: FormApi;
+          public readonly [input]: FieldInputProps<object>;
+          public readonly [meta]: FieldMetaProps;
+        }
+
+        [, fieldElement] = createMockedContextElements(Form, FormField);
+      });
+
+      it('property updates form on input change event', () => {
+        const inputElement = document.createElement('input');
+        inputElement.type = 'text';
+        fieldElement.appendChild(inputElement);
+
+        const [listener] = subscribeField(fieldElement);
+        updateField(fieldElement, listener);
+
+        inputElement.value = 'test';
+        inputElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+        expect(state.change).toHaveBeenCalledWith('test');
+      });
+
+      describe('checkbox', () => {
+        it('sets boolean value if no value exists', () => {
+          const inputElement = document.createElement('input');
+          inputElement.type = 'checkbox';
+          fieldElement.appendChild(inputElement);
+
+          const [listener] = subscribeField(fieldElement);
+          updateField(fieldElement, listener);
+
+          inputElement.checked = true;
+          inputElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+          expect(state.change).toHaveBeenCalledWith(true);
+        });
+
+        it('sets array value if value exists', () => {
+          const inputElement = document.createElement('input');
+          inputElement.type = 'checkbox';
+          inputElement.value = 'foo';
+          fieldElement.appendChild(inputElement);
+
+          const [listener] = subscribeField(fieldElement);
+          updateField(fieldElement, listener);
+
+          inputElement.checked = true;
+          inputElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+          expect(state.change).toHaveBeenCalledWith(['foo']);
+        });
+
+        it('updates array value if checked', () => {
+          const inputElement = document.createElement('input');
+          inputElement.type = 'checkbox';
+          inputElement.value = 'foo';
+
+          fieldElement.appendChild(inputElement);
+
+          state.value = ['bar'];
+
+          const [listener] = subscribeField(fieldElement);
+          updateField(fieldElement, listener);
+
+          inputElement.checked = true;
+          inputElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+          expect(state.change).toHaveBeenCalledWith(['bar', 'foo']);
+        });
+
+        it('removes value if unchecked', () => {
+          const inputElement = document.createElement('input');
+          inputElement.type = 'checkbox';
+          inputElement.value = 'foo';
+          inputElement.checked = true;
+
+          fieldElement.appendChild(inputElement);
+
+          state.value = ['foo'];
+
+          const [listener] = subscribeField(fieldElement);
+          updateField(fieldElement, listener);
+
+          inputElement.checked = false;
+          inputElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+          expect(state.change).toHaveBeenCalledWith([]);
+        });
+
+        it('does nothing if form value is not an array', () => {
+          const inputElement = document.createElement('input');
+          inputElement.type = 'checkbox';
+          inputElement.value = 'foo';
+
+          fieldElement.appendChild(inputElement);
+
+          state.value = undefined;
+
+          const [listener] = subscribeField(fieldElement);
+          updateField(fieldElement, listener);
+
+          inputElement.checked = false;
+          inputElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+          expect(state.change).toHaveBeenCalledWith(undefined);
+        });
+      });
+
+      describe('select', () => {
+        let selectElement: HTMLSelectElement;
+        let option1: HTMLOptionElement;
+        let option2: HTMLOptionElement;
+
+        beforeEach(() => {
+          selectElement = document.createElement('select');
+          option1 = document.createElement('option');
+          option1.value = '1';
+          option1.textContent = 'one';
+
+          option2 = document.createElement('option');
+          option2.value = '2';
+          option2.textContent = 'two';
+
+          selectElement.appendChild(option1);
+          selectElement.appendChild(option2);
+        });
+
+        it('sets the form value to the selected option if selection is single', () => {
+          fieldElement.appendChild(selectElement);
+
+          const [listener] = subscribeField(fieldElement);
+          updateField(fieldElement, listener);
+
+          option2.selected = true;
+          selectElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+          expect(state.change).toHaveBeenCalledWith('2');
+        });
+
+        it('sets the form value to the array of selected option if selection is multiple', () => {
+          selectElement.multiple = true;
+          fieldElement.appendChild(selectElement);
+
+          const [listener] = subscribeField(fieldElement);
+          updateField(fieldElement, listener);
+
+          option1.selected = true;
+          option2.selected = true;
+
+          selectElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+          expect(state.change).toHaveBeenCalledWith(['1', '2']);
+        });
+      });
+    });
   });
 };
 

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -150,9 +150,6 @@ const testField = () => {
       expect(scheduler).toHaveBeenCalledTimes(2);
       expect(fieldElement[input]).toEqual({
         name: 'test',
-        onBlur: jasmine.any(Function),
-        onChange: jasmine.any(Function),
-        onFocus: jasmine.any(Function),
         value: fieldValue,
       });
 
@@ -399,7 +396,7 @@ const testField = () => {
         const [listener] = subscribeField(fieldElement);
         updateField(fieldElement, listener);
 
-        fieldElement[input].onBlur();
+        fieldElement.dispatchEvent(new Event('blur'));
 
         expect(state.blur).toHaveBeenCalled();
       });
@@ -430,13 +427,13 @@ const testField = () => {
         const [listener] = subscribeField(fieldElement);
         updateField(fieldElement, listener);
 
-        fieldElement[input].onBlur();
+        fieldElement.dispatchEvent(new Event('blur'));
 
         expect(fieldElement.format).toHaveBeenCalledWith(fieldValue, 'test');
         expect(state.change).toHaveBeenCalledWith(fieldValue);
       });
 
-      it('calls change() method of field state [input].onChange() is called', () => {
+      it('calls change() method of field state when new "change" event is fired', () => {
         @form()
         class Form extends CustomElement {}
 
@@ -451,9 +448,9 @@ const testField = () => {
         const [listener] = subscribeField(fieldElement);
         updateField(fieldElement, listener);
 
-        const newFieldValue = {};
+        const newFieldValue: object = {};
 
-        fieldElement[input].onChange(newFieldValue);
+        fieldElement.dispatchEvent(new CustomEvent('change', {detail: newFieldValue}));
 
         expect(state.change).toHaveBeenCalledWith(newFieldValue);
       });
@@ -482,7 +479,7 @@ const testField = () => {
 
         const newFieldValue = JSON.stringify({});
 
-        fieldElement[input].onChange(newFieldValue);
+        fieldElement.dispatchEvent(new CustomEvent('change', {detail: newFieldValue}));
 
         expect(fieldElement.parse).toHaveBeenCalledWith(newFieldValue, 'test');
         expect(state.change).toHaveBeenCalledWith({});
@@ -503,7 +500,7 @@ const testField = () => {
         const [listener] = subscribeField(fieldElement);
         updateField(fieldElement, listener);
 
-        fieldElement[input].onFocus();
+        fieldElement.dispatchEvent(new Event('focus'));
 
         expect(state.focus).toHaveBeenCalled();
       });

--- a/packages/form/src/createFormContext.js
+++ b/packages/form/src/createFormContext.js
@@ -15,4 +15,6 @@ const createFormContext = () => {
   };
 };
 
+export const {field, form, formApi} = createFormContext();
+
 export default createFormContext;

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -4,7 +4,7 @@ import {accessor, field as ffield, method, lifecycleKeys} from '@corpuscule/util
 import defaultScheduler from '@corpuscule/utils/lib/scheduler';
 import shallowEqual from '@corpuscule/utils/lib/shallowEqual';
 import {input as $input, meta as $meta} from './tokens/lifecycle';
-import {all} from './utils';
+import {all, getTargetValue} from './utils';
 
 const [connectedCallbackKey, disconnectedCallbackKey] = lifecycleKeys;
 
@@ -215,11 +215,10 @@ const createField = (consumer, $formApi, $$form) => {
           {
             key: $$onChange,
             value({detail, target}) {
-              const changeValue = target ? target.value : detail;
-
               const [parse] = getConfigProperties(this, 'parse');
+              const {change, name, value} = this[$$formState];
 
-              const {change, name} = this[$$formState];
+              const changeValue = detail || getTargetValue(target, value);
 
               change(parse ? parse(changeValue, name) : changeValue);
             },

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -148,6 +148,10 @@ const createField = (consumer, $formApi, $$form) => {
           {
             key: connectedCallbackKey,
             value() {
+              this.addEventListener('blur', this[$$onBlur]);
+              this.addEventListener('change', this[$$onChange]);
+              this.addEventListener('focus', this[$$onFocus]);
+
               this[$$superConnectedCallback]();
               this[$$subscribe]();
             },
@@ -158,6 +162,10 @@ const createField = (consumer, $formApi, $$form) => {
           {
             key: disconnectedCallbackKey,
             value() {
+              this.removeEventListener('blur', this[$$onBlur]);
+              this.removeEventListener('change', this[$$onChange]);
+              this.removeEventListener('focus', this[$$onFocus]);
+
               this[$$unsubscribe]();
               this[$$superDisconnectedCallback]();
             },
@@ -206,12 +214,14 @@ const createField = (consumer, $formApi, $$form) => {
         method(
           {
             key: $$onChange,
-            value(value) {
+            value({detail, target}) {
+              const changeValue = target ? target.value : detail;
+
               const [parse] = getConfigProperties(this, 'parse');
 
               const {change, name} = this[$$formState];
 
-              change(parse ? parse(value, name) : value);
+              change(parse ? parse(changeValue, name) : changeValue);
             },
           },
           {isBound: true},
@@ -283,9 +293,6 @@ const createField = (consumer, $formApi, $$form) => {
 
               this[$input] = {
                 name,
-                onBlur: this[$$onBlur],
-                onChange: this[$$onChange],
-                onFocus: this[$$onFocus],
                 value: !formatOnBlur && format ? format(value, name) : value,
               };
 

--- a/packages/form/src/index.d.ts
+++ b/packages/form/src/index.d.ts
@@ -29,9 +29,6 @@ export const formOption: (configKey: FormConfigKey) => PropertyDecorator;
 
 export interface FieldInputProps<T> {
   readonly name: string;
-  readonly onBlur: () => void;
-  readonly onChange: (value: T) => void;
-  readonly onFocus: () => void;
   readonly value: T;
 }
 

--- a/packages/form/src/index.d.ts
+++ b/packages/form/src/index.d.ts
@@ -25,6 +25,7 @@ export interface Form {
 
 export type FormDecorator = (params?: FormDecoratorParams) => ClassDecorator;
 
+export const form: FormDecorator;
 export const formOption: (configKey: FormConfigKey) => PropertyDecorator;
 
 export interface FieldInputProps<T> {
@@ -62,6 +63,7 @@ export interface Field<T> {
 
 export type FieldDecorator = (params?: FieldDecoratorParams) => ClassDecorator;
 
+export const field: FieldDecorator;
 export const fieldOption: (configKey: FieldConfigKey) => PropertyDecorator;
 
 export interface FormContext {
@@ -71,3 +73,9 @@ export interface FormContext {
 }
 
 export const createFormContext: () => FormContext;
+
+export class Input extends HTMLInputElement {}
+export class Select extends HTMLSelectElement {}
+
+export const createInputField: (field: FieldDecorator) => Input;
+export const createSelectField: (field: FieldDecorator) => Select;

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -1,9 +1,4 @@
-import createFormContext from './createFormContext';
-
+export {default as createFormContext, field, form, formApi} from './createFormContext';
 export {fieldOption} from './field';
 export {formOption} from './form';
 export * from './tokens/lifecycle';
-
-const {field, form, formApi} = createFormContext();
-
-export {createFormContext, field, form, formApi};

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -5,3 +5,36 @@ export const all = formSubscriptionItems.reduce((result, key) => {
 
   return result;
 }, {});
+
+export const getTargetValue = (
+  {checked, defaultValue, selectedOptions, type, value},
+  formValue,
+) => {
+  switch (type) {
+    case 'checkbox': {
+      // Form maintains an array, not just a boolean
+      if (defaultValue) {
+        // Add value to formValue array
+        if (checked) {
+          return Array.isArray(formValue) ? formValue.concat(value) : [value];
+        }
+
+        // Remove value from formValue array
+        if (!Array.isArray(formValue)) {
+          return formValue;
+        }
+
+        return formValue.filter(v => v !== value);
+      }
+
+      // It's just a boolean
+      return !!checked;
+    }
+    case 'select-one':
+      return selectedOptions[0].value;
+    case 'select-multiple':
+      return Array.from(selectedOptions, option => option.value);
+    default:
+      return value;
+  }
+};

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
               cacheDirectory: true,
               cacheCompression: false,
               plugins: [
-                [require('@babel/plugin-proposal-decorators'), {decoratorsBeforeExport: true}],
+                [require('@babel/plugin-proposal-decorators'), {decoratorsBeforeExport: false}],
                 require('@babel/plugin-proposal-class-properties'),
               ],
               presets: [require('@babel/preset-typescript')],


### PR DESCRIPTION
This PR introduces `@corpuscule/form` ability to consume events fired by default HTML elements like `<input>`, `<select>` etc. 

Also it fixes previous implementation that based on functions, not event listeners. It was wrong since Web Components communicates with events.