### PR TITLE
Improve styles decorator

### DIFF
--- a/packages/styles/__tests__/index.ts
+++ b/packages/styles/__tests__/index.ts
@@ -5,7 +5,71 @@ import styles, {stylesAttachedCallback} from '../src';
 describe('@corpuscule/styles', () => {
   const rawStyles = '.foo{color: red;}';
 
-  it('appends styles to the shadow root', async () => {
+  describe('file links', () => {
+    it('appends "link" tags for urls with same origin', async () => {
+      const [promise, resolve] = createTestingPromise();
+
+      @styles(new URL('./styles.css', location.origin))
+      class Test extends HTMLElement {
+        public constructor() {
+          super();
+          this.attachShadow({mode: 'open'});
+        }
+
+        public connectedCallback(): void {
+          this.shadowRoot!.innerHTML = '<div>Bar</div>';
+        }
+
+        public [stylesAttachedCallback](): void {
+          resolve();
+        }
+      }
+
+      customElements.define(genName(), Test);
+
+      const test = new Test();
+      test.connectedCallback();
+
+      await promise;
+
+      expect(test.shadowRoot!.innerHTML).toBe(
+        `<link rel="stylesheet" type="text/css" href="/styles.css"><div>Bar</div>`,
+      );
+    });
+
+    it('appends "link" tags for urls with different origins', async () => {
+      const [promise, resolve] = createTestingPromise();
+
+      @styles(new URL('./styles.css', 'https://foo'))
+      class Test extends HTMLElement {
+        public constructor() {
+          super();
+          this.attachShadow({mode: 'open'});
+        }
+
+        public connectedCallback(): void {
+          this.shadowRoot!.innerHTML = '<div>Bar</div>';
+        }
+
+        public [stylesAttachedCallback](): void {
+          resolve();
+        }
+      }
+
+      customElements.define(genName(), Test);
+
+      const test = new Test();
+      test.connectedCallback();
+
+      await promise;
+
+      expect(test.shadowRoot!.innerHTML).toBe(
+        `<link rel="stylesheet" type="text/css" href="https://foo/styles.css"><div>Bar</div>`,
+      );
+    });
+  });
+
+  it('appends raw styles to the shadow root', async () => {
     const [promise, resolve] = createTestingPromise();
 
     @styles(rawStyles)

--- a/packages/styles/__tests__/index.ts
+++ b/packages/styles/__tests__/index.ts
@@ -1,55 +1,32 @@
-// tslint:disable:max-classes-per-file
-import styles, {link, style} from '../src';
+// tslint:disable:max-classes-per-file no-inner-html await-promise
+import {genName} from '../../../test/utils';
+import styles from '../src';
 
 describe('@corpuscule/styles', () => {
-  const rawStyles = '.test{padding:10px}';
-  let container: HTMLElement;
+  const rawStyles = '.foo{color: red;}';
 
-  beforeEach(() => {
-    container = document.createElement('div');
-  });
-
-  it('should create a <link> tag if path is received', () => {
-    @styles('/styles.css')
-    class Test extends HTMLElement {
-      public static [style]: HTMLElement;
-    }
-
-    const {[style]: styleElement} = Test;
-    container.appendChild(styleElement);
-
-    expect(container.innerHTML).toBe('<link rel="stylesheet" type="text/css" href="/styles.css">');
-  });
-
-  it('should create a <style/> tag if styles are received', () => {
+  it('appends styles to the shadow root', async () => {
     @styles(rawStyles)
     class Test extends HTMLElement {
-      public static [style]: HTMLElement;
+      public constructor() {
+        super();
+        this.attachShadow({mode: 'open'});
+      }
+
+      public connectedCallback(): void {
+        this.shadowRoot!.innerHTML = '<div class="foo">Bar</div>';
+      }
     }
 
-    const {[style]: styleElement} = Test;
-    container.appendChild(styleElement);
+    customElements.define(genName(), Test);
 
-    expect(container.innerHTML).toBe(`<style>${rawStyles}</style>`);
-  });
+    const test = new Test();
+    test.connectedCallback();
 
-  it('should allow to insert different style types', () => {
-    @styles('/styles.css', rawStyles)
-    class Test extends HTMLElement {
-      public static [style]: HTMLElement;
-    }
+    await null;
 
-    const {[style]: styleElement} = Test;
-    container.appendChild(styleElement);
-
-    expect(container.innerHTML).toBe(
-      `<link rel="stylesheet" type="text/css" href="/styles.css"><style>${rawStyles}</style>`,
+    expect(test.shadowRoot!.innerHTML).toBe(
+      `<div class="foo">Bar</div><style>${rawStyles}</style>`,
     );
-  });
-
-  describe('link()', () => {
-    it('should build url', () => {
-      expect(link('./style.css', 'http://localhost/')).toBe('http://localhost/style.css');
-    });
   });
 });

--- a/packages/styles/src/index.d.ts
+++ b/packages/styles/src/index.d.ts
@@ -1,6 +1,17 @@
 export const stylesAttachedCallback: unique symbol;
 
 // tslint:disable-next-line:readonly-array
-declare const styles: <T extends Array<string | URL>>(...pathsOrStyles: T) => ClassDecorator;
+export type StylesDecorator = <T extends Array<string | URL>>(
+  ...pathsOrStyles: T
+) => ClassDecorator;
+
+export interface StylesDecoratorOptions {
+  readonly adoptedStyleSheets: boolean;
+  readonly shadyCSS: boolean;
+}
+
+export const createStylesDecorator: (options: StylesDecoratorOptions) => StylesDecorator;
+
+declare const styles: StylesDecorator;
 
 export default styles;

--- a/packages/styles/src/index.d.ts
+++ b/packages/styles/src/index.d.ts
@@ -1,3 +1,5 @@
+export const stylesAttachedCallback: unique symbol;
+
 // tslint:disable-next-line:readonly-array
 declare const styles: <T extends Array<string | URL>>(...pathsOrStyles: T) => ClassDecorator;
 

--- a/packages/styles/src/index.d.ts
+++ b/packages/styles/src/index.d.ts
@@ -1,8 +1,4 @@
-export const link: (url: string, base: string) => string;
-
-export const style: unique symbol;
-
 // tslint:disable-next-line:readonly-array
-declare const styles: <T extends string[]>(...pathsOrStyles: T) => ClassDecorator;
+declare const styles: <T extends Array<string | URL>>(...pathsOrStyles: T) => ClassDecorator;
 
 export default styles;

--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -24,7 +24,10 @@ const styles = (...pathsOrStyles) => ({elements, kind}) => {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
       link.type = 'text/css';
-      link.href = pathOrStyle;
+      link.href =
+        pathOrStyle.origin === location.origin
+          ? pathOrStyle.pathname + pathOrStyle.search
+          : pathOrStyle;
       template.content.appendChild(link);
     } else if (supportsShadyCSS) {
       // If ShadyCSS

--- a/packages/styles/src/tokens.js
+++ b/packages/styles/src/tokens.js
@@ -1,1 +1,0 @@
-export const style = Symbol('style');

--- a/packages/styles/src/utils.js
+++ b/packages/styles/src/utils.js
@@ -1,1 +1,0 @@
-export const link = (url, base) => new URL(url, base).toString();


### PR DESCRIPTION
This PR introduces major refactoring for the `@styles` decorator. Main changes are following:
* Generation of `<link>` elements requires instances of built-in `URL` class. No more regexp matching. 
* Allow using [`ShadyCSS`](https://github.com/webcomponents/shadycss). 
* Allow using upcoming [`Constructable Stylesheet Objects`](https://wicg.github.io/construct-stylesheets/index.html). 
* Styles are set automatically after `ShadowRoot` children appended for the first time. No more `[layout]` property. 