### PR TITLE
Add element creator function

### DIFF
--- a/packages/element/__tests__/decorators/element.ts
+++ b/packages/element/__tests__/decorators/element.ts
@@ -1,8 +1,8 @@
 // tslint:disable:no-unnecessary-class max-classes-per-file no-unbound-method no-empty
 import {createTestingPromise, CustomElement, genName} from '../../../../test/utils';
 import {
+  createElementDecorator,
   createRoot,
-  element as basicElement,
   internalChangedCallback,
   propertyChangedCallback,
   render,
@@ -22,8 +22,7 @@ const testElementDecorator = () => {
       define = spyOn(customElements, 'define');
       define.and.callThrough();
 
-      element = (name, params = {}) =>
-        basicElement(name, {...params, renderer: rendererSpy, scheduler: schedulerSpy});
+      element = createElementDecorator({renderer: rendererSpy, scheduler: schedulerSpy});
     });
 
     it('adds element to a custom elements registry', () => {

--- a/packages/element/src/decorators/element.js
+++ b/packages/element/src/decorators/element.js
@@ -21,11 +21,11 @@ const filteringNames = ['is', 'observedAttributes'];
 
 const rootProperty = new WeakMap();
 
-const element = (name, {extends: builtin, renderer, scheduler = defaultScheduler}) => ({
-  kind,
-  elements,
-}) => {
-  assertKind('element', 'class', kind);
+const createElementDecorator = ({renderer, scheduler = defaultScheduler}) => (
+  name,
+  {extends: builtin} = {},
+) => ({kind, elements}) => {
+  assertKind('createElementDecorator', 'class', kind);
 
   const hasRender = elements.some(({key}) => key === $render);
 
@@ -199,4 +199,4 @@ const element = (name, {extends: builtin, renderer, scheduler = defaultScheduler
   };
 };
 
-export default element;
+export default createElementDecorator;

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -4,8 +4,7 @@ export interface ComputingPair {
   readonly observer: PropertyDecorator;
 }
 
-export interface ElementDecoratorParams {
-  readonly extends?: keyof HTMLElementTagNameMap;
+export interface ElementDecoratorOptions {
   readonly renderer: (
     result: unknown,
     container: Element | DocumentFragment,
@@ -14,12 +13,18 @@ export interface ElementDecoratorParams {
   readonly scheduler?: (callback: () => void) => Promise<void>;
 }
 
+export interface ElementDecoratorParams {
+  readonly extends?: keyof HTMLElementTagNameMap;
+}
+
+export type ElementDecorator = (name: string, params: ElementDecoratorParams) => ClassDecorator;
+
 export type AttributeGuard = BooleanConstructor | NumberConstructor | StringConstructor;
 export type PropertyGuard = (value: unknown) => boolean;
 
 export const attribute: (attributeName: string, guard: AttributeGuard) => PropertyDecorator;
 
-export const element: (name: string, params: ElementDecoratorParams) => ClassDecorator;
+export const createElementDecorator: (options: ElementDecoratorOptions) => ElementDecorator;
 
 export const internal: PropertyDecorator;
 export const property: (guard?: PropertyGuard) => PropertyDecorator;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -1,6 +1,6 @@
 export {default as attribute} from './decorators/attribute';
 export {default as createComputingPair} from './decorators/computingPair';
-export {default as element} from './decorators/element';
+export {default as createElementDecorator} from './decorators/element';
 export {default as internal} from './decorators/internal';
 export {default as property} from './decorators/property';
 export * from './tokens/lifecycle';


### PR DESCRIPTION
This PR replaces bare `@element` decorator with a creator function `createElementDecorator` that allows to define `renderer` and `scheduler` during the configuration step.