### PR TITLE
Add shady renderer

### DIFF
--- a/packages/lit-html-renderer/__tests__/index.ts
+++ b/packages/lit-html-renderer/__tests__/index.ts
@@ -1,7 +1,9 @@
-import testRenderLitHtml from './renderLitHtml';
+import testRegularRender from './regular';
+import testShadyRender from './shady';
 import testWithCustomElement from './withCustomElement';
 
 describe('@corpuscule/lit-html-renderer', () => {
-  testRenderLitHtml();
+  testRegularRender();
+  testShadyRender();
   testWithCustomElement();
 });

--- a/packages/lit-html-renderer/__tests__/regular.ts
+++ b/packages/lit-html-renderer/__tests__/regular.ts
@@ -3,7 +3,7 @@ import {html} from 'lit-html';
 import {render} from '../../../test/mocks/litHtml';
 import renderLitHtml from '../src';
 
-const testRenderLitHtml = () => {
+const testRegularRender = () => {
   describe('renderLitHtml', () => {
     beforeEach(() => {
       render.calls.reset();
@@ -25,4 +25,4 @@ const testRenderLitHtml = () => {
   });
 };
 
-export default testRenderLitHtml;
+export default testRegularRender;

--- a/packages/lit-html-renderer/__tests__/shady.ts
+++ b/packages/lit-html-renderer/__tests__/shady.ts
@@ -1,0 +1,35 @@
+// tslint:disable:no-object-literal-type-assertion
+import {html} from 'lit-html/lib/shady-render';
+import {render} from '../../../test/mocks/litHtmlShady';
+import {genName} from '../../../test/utils';
+import renderShadyLitHtml from '../src/shady';
+
+const testShadyRender = () => {
+  describe('renderShadyLitHtml', () => {
+    beforeEach(() => {
+      render.calls.reset();
+    });
+
+    it('renders lit-html shady template result', () => {
+      const name = genName();
+      class Test extends HTMLElement {}
+      customElements.define(name, Test);
+
+      const test = new Test();
+
+      const result = html`
+        <div>Test</div>
+      `;
+      const container = document.createElement('div');
+
+      renderShadyLitHtml(result, container, test);
+
+      expect(render).toHaveBeenCalledWith(result, container, {
+        eventContext: test,
+        scopeName: name,
+      });
+    });
+  });
+};
+
+export default testShadyRender;

--- a/packages/lit-html-renderer/src/index.js
+++ b/packages/lit-html-renderer/src/index.js
@@ -1,9 +1,9 @@
 import {render} from 'lit-html';
 
-const renderLitHtml = (result, container, context) => {
+const renderRegular = (result, container, context) => {
   render(result, container, {
     eventContext: context,
   });
 };
 
-export default renderLitHtml;
+export default renderRegular;

--- a/packages/lit-html-renderer/src/shady.d.ts
+++ b/packages/lit-html-renderer/src/shady.d.ts
@@ -1,0 +1,9 @@
+import {TemplateResult} from 'lit-html';
+
+declare const renderLitHtml: (
+  result: TemplateResult,
+  root: Element | DocumentFragment,
+  context: unknown,
+) => void;
+
+export default renderLitHtml;

--- a/packages/lit-html-renderer/src/shady.js
+++ b/packages/lit-html-renderer/src/shady.js
@@ -1,0 +1,10 @@
+import {render} from 'lit-html/lib/shady-render';
+
+const renderLitHtml = (result, container, context) => {
+  render(result, container, {
+    eventContext: context,
+    scopeName: context.localName,
+  });
+};
+
+export default renderLitHtml;

--- a/packages/lit-html-renderer/src/shady.js
+++ b/packages/lit-html-renderer/src/shady.js
@@ -1,10 +1,10 @@
 import {render} from 'lit-html/lib/shady-render';
 
-const renderLitHtml = (result, container, context) => {
+const renderShady = (result, container, context) => {
   render(result, container, {
     eventContext: context,
     scopeName: context.localName,
   });
 };
 
-export default renderLitHtml;
+export default renderShady;

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -2,7 +2,7 @@ const packages = {
   context: ['index'],
   element: ['index'],
   form: ['index'],
-  'lit-html-renderer': ['index', 'withCustomElement'],
+  'lit-html-renderer': ['index', 'shady', 'withCustomElement'],
   redux: ['index'],
   router: ['index'],
   styles: ['index'],

--- a/test/mocks/litHtmlShady.ts
+++ b/test/mocks/litHtmlShady.ts
@@ -1,0 +1,4 @@
+// tslint:disable:no-implicit-dependencies
+export {html} from 'lit-html/lib/shady-render.js';
+
+export const render = jasmine.createSpy('render');

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
       '@corpuscule/context': resolve(__dirname, './mocks/context'),
       'final-form$': resolve(__dirname, './mocks/finalForm'),
       'lit-html$': resolve(__dirname, './mocks/litHtml'),
+      'lit-html/lib/shady-render$': resolve(__dirname, './mocks/litHtmlShady'),
       'universal-router$': resolve(__dirname, './mocks/universalRouter'),
     },
     extensions: ['.js', '.ts'],


### PR DESCRIPTION
Adds option to use ShadyCSS renderer from [`lit-html`](https://lit-html.polymer-project.org/). It is placed as a separate `shady.js` file that can be imported following way:
```javascript
import renderLitHtml from '@corpuscule/lit-html-renderer/lib/shady';
```
The `renderLitHtml` function has the same signature for both shady and non-shady renderers