### PR TITLE
Add property utils

### DIFF
--- a/packages/utils/__tests__/index.ts
+++ b/packages/utils/__tests__/index.ts
@@ -2,6 +2,7 @@ import testAddToRegistry from './addToRegistry';
 import testAsserts from './asserts';
 import testCreateSupers from './createSupers';
 import testDescriptors from './descriptors';
+import testPropertyUtils from './propertyUtils';
 import testSchedule from './scheduler';
 
 describe('@corpuscule/utils', () => {
@@ -9,5 +10,6 @@ describe('@corpuscule/utils', () => {
   testAsserts();
   testDescriptors();
   testCreateSupers();
+  testPropertyUtils();
   testSchedule();
 });

--- a/packages/utils/__tests__/propertyUtils.ts
+++ b/packages/utils/__tests__/propertyUtils.ts
@@ -1,0 +1,145 @@
+// tslint:disable:no-unnecessary-class
+import {call, getName, getValue, isPublic, setValue} from '../src/propertyUtils';
+
+class PrivateName extends WeakMap {
+  public readonly description: string;
+
+  public constructor(description: string = '') {
+    super();
+
+    this.description = description;
+  }
+}
+
+const testPropertyUtils = () => {
+  describe('propertyUtils', () => {
+    describe('isPublic', () => {
+      it('returns true if property is string or number', () => {
+        expect(isPublic('foo')).toBeTruthy();
+        expect(isPublic(1)).toBeTruthy();
+      });
+
+      it('returns true if property is symbol', () => {
+        const bar = Symbol();
+
+        expect(isPublic(bar)).toBeTruthy();
+      });
+
+      it('returns false if property is WeakMap or PrivateName', () => {
+        const baz = new PrivateName('baz');
+
+        expect(isPublic(baz)).not.toBeTruthy();
+      });
+    });
+
+    describe('getValue', () => {
+      it('gets value of string or symbol property', () => {
+        class Test {
+          public foo: string = 'test';
+        }
+
+        const test = new Test();
+
+        expect(getValue(test, 'foo')).toBe('test');
+      });
+
+      it('gets value of WeakMap or PrivateName property', () => {
+        const foo = new PrivateName('foo');
+
+        class Test {
+          public constructor() {
+            foo.set(this, 'test');
+          }
+        }
+
+        const test = new Test();
+
+        expect(getValue(test, foo)).toBe('test');
+      });
+    });
+
+    describe('setValue', () => {
+      it('sets value of string or symbol property', () => {
+        class Test {
+          public foo: string = 'test';
+        }
+
+        const test = new Test();
+
+        setValue(test, 'foo', 'new test');
+
+        expect(test.foo).toBe('new test');
+      });
+
+      it('sets value of WeakMap or PrivateName property', () => {
+        const foo = new PrivateName('foo');
+
+        class Test {
+          public constructor() {
+            foo.set(this, 'test');
+          }
+        }
+
+        const test = new Test();
+
+        setValue(test, foo, 'new test');
+
+        expect(foo.get(test)).toBe('new test');
+      });
+    });
+
+    describe('call', () => {
+      it('calls method of string or symbol property', () => {
+        const spy = jasmine.createSpy('foo');
+
+        class Test {
+          public foo(...args: number[]): void {
+            spy(this, args);
+          }
+        }
+
+        const test = new Test();
+
+        call(test, 'foo', 1, 2, 3);
+
+        expect(spy).toHaveBeenCalledWith(test, [1, 2, 3]);
+      });
+
+      it('calls method of WeakMap or PrivateName property', () => {
+        const spy = jasmine.createSpy('foo');
+        const foo = new PrivateName('foo');
+
+        class Test {
+          public constructor() {
+            foo.set(this, (...args: any[]) => {
+              spy(this, args);
+            });
+          }
+        }
+
+        const test = new Test();
+
+        call(test, foo, 1, 2, 3);
+
+        expect(spy).toHaveBeenCalledWith(test, [1, 2, 3]);
+      });
+    });
+
+    describe('getName', () => {
+      it('gets property itself if it is a string or number', () => {
+        expect(getName('foo')).toBe('foo');
+        expect(getName(1)).toBe(1);
+      });
+
+      it('gets description if property is a symbol', () => {
+        expect(getName(Symbol('bar'))).toBe('bar');
+      });
+
+      it('gets description if property is PrivateName', () => {
+        expect(getName(new PrivateName('baz'))).toBe('baz');
+      });
+    });
+  });
+};
+
+export default testPropertyUtils;

--- a/packages/utils/src/propertyUtils.d.ts
+++ b/packages/utils/src/propertyUtils.d.ts
@@ -1,0 +1,30 @@
+export const isPublic: (property: PropertyKey | WeakMap<object, unknown>) => boolean;
+
+export const getValue: {
+  <T, P extends keyof T>(self: T, property: P): T[P];
+  (self: unknown, property: WeakMap<object, unknown>): unknown;
+};
+
+export const setValue: {
+  <T, P extends keyof T>(self: T, property: P, value: T[P]): void;
+  (self: unknown, property: WeakMap<object, unknown>, value: unknown): void;
+};
+
+// tslint:disable:readonly-array
+export const call: {
+  <T extends Record<P, (...a: any[]) => any>, P extends keyof T>(
+    self: T,
+    property: P,
+    ...args: Parameters<T[P]>
+  ): ReturnType<T[P]>;
+  <A extends any[]>(
+    self: unknown,
+    property: WeakMap<object, (...args: A) => void>,
+    ...args: A
+  ): unknown;
+};
+// tslint:enable:readonly-array
+
+export const getName: <P extends PropertyKey | {readonly description: string}>(
+  property: P,
+) => P extends number ? number : string;

--- a/packages/utils/src/propertyUtils.js
+++ b/packages/utils/src/propertyUtils.js
@@ -1,0 +1,15 @@
+export const isPublic = property =>
+  typeof property === 'number' || typeof property === 'string' || typeof property === 'symbol';
+
+export const getValue = (self, property) =>
+  isPublic(property) ? self[property] : property.get(self);
+
+// eslint-disable-next-line no-return-assign
+export const setValue = (self, property, value) =>
+  isPublic(property) ? (self[property] = value) : property.set(self, value);
+
+export const call = (self, property, ...args) =>
+  isPublic(property) ? self[property](...args) : property.get(self).apply(self, args);
+
+export const getName = property =>
+  typeof property === 'string' || typeof property === 'number' ? property : property.description;


### PR DESCRIPTION
This PR adds utils to work with private and public properties in a unified way. Also it includes a function `getName` that can get string name of each function: public, private or symbolic.