### PR TITLE
Fix lifecycle issue along with many others

### DIFF
--- a/packages/context/src/utils.js
+++ b/packages/context/src/utils.js
@@ -7,4 +7,6 @@ export const checkValue = (value, target) => {
 };
 
 export const filter = elements =>
-  elements.filter(({key, placement}) => !(lifecycleKeys.includes(key) && placement !== 'own'));
+  elements.filter(
+    ({key, placement}) => !(lifecycleKeys.includes(key) && placement === 'prototype'),
+  );

--- a/packages/element/__tests__/attribute.ts
+++ b/packages/element/__tests__/attribute.ts
@@ -1,6 +1,6 @@
 // tslint:disable:max-classes-per-file
-import {CustomElement, genName} from '../../../../test/utils';
-import {attribute} from '../../src';
+import {CustomElement, genName} from '../../../test/utils';
+import {attribute} from '../src';
 
 const testAttributeDecorator = () => {
   describe('@attribute', () => {

--- a/packages/element/__tests__/computingPair.ts
+++ b/packages/element/__tests__/computingPair.ts
@@ -1,5 +1,5 @@
 // tslint:disable:max-classes-per-file
-import {ComputingPair, createComputingPair} from '../../src';
+import {ComputingPair, createComputingPair} from '../src';
 
 const repeatGetTenTimes = <C extends object, M extends keyof C, T extends C[M]>(
   instance: C,

--- a/packages/element/__tests__/decorators/element.ts
+++ b/packages/element/__tests__/decorators/element.ts
@@ -376,6 +376,33 @@ const testElementDecorator = () => {
       }).not.toThrow();
     });
 
+    it('executes connectedCallback on real DOM', async () => {
+      const connectedCallbackSpy = jasmine.createSpy('connectedCallback');
+
+      const [promise, resolve] = createTestingPromise();
+
+      @element(genName())
+      class Test extends HTMLElement {
+        public connectedCallback(): void {
+          connectedCallbackSpy();
+          resolve();
+        }
+
+        public [render](): null {
+          return null;
+        }
+      }
+
+      const test = new Test();
+
+      document.body.appendChild(test);
+      await promise;
+
+      expect(connectedCallbackSpy).toHaveBeenCalled();
+      expect(schedulerSpy).toHaveBeenCalled();
+      document.body.innerHTML = ''; // tslint:disable-line:no-inner-html
+    });
+
     describe('elements extending', () => {
       it('allows extending existing element', () => {
         @element(genName())

--- a/packages/element/__tests__/element.ts
+++ b/packages/element/__tests__/element.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-unnecessary-class max-classes-per-file no-unbound-method no-empty
-import {createTestingPromise, CustomElement, genName} from '../../../../test/utils';
+import {createTestingPromise, CustomElement, genName} from '../../../test/utils';
 import {
   createElementDecorator,
   createRoot,
@@ -7,7 +7,7 @@ import {
   propertyChangedCallback,
   render,
   updatedCallback,
-} from '../../src';
+} from '../src';
 
 const testElementDecorator = () => {
   describe('@element', () => {

--- a/packages/element/__tests__/index.ts
+++ b/packages/element/__tests__/index.ts
@@ -1,8 +1,8 @@
-import testAttributeDecorator from './decorators/attribute';
-import testComputingPair from './decorators/computingPair';
-import testElementDecorator from './decorators/element';
-import testInternalDecorator from './decorators/internal';
-import testPropertyDecorator from './decorators/property';
+import testAttributeDecorator from './attribute';
+import testComputingPair from './computingPair';
+import testElementDecorator from './element';
+import testInternalDecorator from './internal';
+import testPropertyDecorator from './property';
 
 describe('@corpuscule/element', () => {
   testAttributeDecorator();

--- a/packages/element/__tests__/internal.ts
+++ b/packages/element/__tests__/internal.ts
@@ -1,5 +1,5 @@
 // tslint:disable:max-classes-per-file
-import {internal, internalChangedCallback} from '../../src';
+import {internal, internalChangedCallback} from '../src';
 
 class CorpusculeElementMock {
   public [internalChangedCallback](

--- a/packages/element/__tests__/property.ts
+++ b/packages/element/__tests__/property.ts
@@ -1,5 +1,5 @@
 // tslint:disable:max-classes-per-file
-import {property, propertyChangedCallback} from '../../src';
+import {property, propertyChangedCallback} from '../src';
 
 class CorpusculeElementMock {
   public [propertyChangedCallback](

--- a/packages/element/src/attribute.js
+++ b/packages/element/src/attribute.js
@@ -1,5 +1,5 @@
-import {accessor} from '@corpuscule/utils/lib/descriptors';
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
+import {accessor} from '@corpuscule/utils/lib/descriptors';
 
 const attribute = (name, guard) => descriptor => {
   assertKind('attribute', Kind.Field, descriptor);

--- a/packages/element/src/computingPair.js
+++ b/packages/element/src/computingPair.js
@@ -1,6 +1,6 @@
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
 import {accessor, field} from '@corpuscule/utils/lib/descriptors';
-import {assertElementProperty} from '../utils';
+import {assertElementProperty} from './utils';
 
 const createComputingPair = () => {
   const registry = new WeakMap();

--- a/packages/element/src/decorators/element.js
+++ b/packages/element/src/decorators/element.js
@@ -185,8 +185,6 @@ const createElementDecorator = ({renderer, scheduler = defaultScheduler}) => (
       }),
     ],
     finisher(target) {
-      customElements.define(name, target, builtin && {extends: builtin});
-
       finish(target, {
         [$createRoot]: isShadow
           ? function() {
@@ -194,6 +192,8 @@ const createElementDecorator = ({renderer, scheduler = defaultScheduler}) => (
             }
           : noop,
       });
+
+      customElements.define(name, target, builtin && {extends: builtin});
     },
     kind,
   };

--- a/packages/element/src/element.js
+++ b/packages/element/src/element.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-invalid-this, prefer-arrow-callback */
 import {assertKind, Kind} from '@corpuscule/utils/lib/asserts';
 import {field, method, lifecycleKeys} from '@corpuscule/utils/lib/descriptors';
+import getSupers from '@corpuscule/utils/lib/getSupers';
 import {method as lifecycleMethod} from '@corpuscule/utils/lib/lifecycleDescriptors';
 import defaultScheduler from '@corpuscule/utils/lib/scheduler';
 import {
@@ -9,9 +10,8 @@ import {
   propertyChangedCallback as $propertyChangedCallback,
   render as $render,
   internalChangedCallback as $internalChangedCallback,
-} from '../tokens/lifecycle';
-import getSupers from '@corpuscule/utils/lib/getSupers';
-import {shadowElements} from '../utils';
+} from './tokens/lifecycle';
+import {shadowElements} from './utils';
 
 const attributeChangedCallbackKey = 'attributeChangedCallback';
 const [connectedCallbackKey] = lifecycleKeys;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -1,6 +1,6 @@
-export {default as attribute} from './decorators/attribute';
-export {default as createComputingPair} from './decorators/computingPair';
-export {default as createElementDecorator} from './decorators/element';
-export {default as internal} from './decorators/internal';
-export {default as property} from './decorators/property';
+export {default as attribute} from './attribute';
+export {default as createComputingPair} from './computingPair';
+export {default as createElementDecorator} from './element';
+export {default as internal} from './internal';
+export {default as property} from './property';
 export * from './tokens/lifecycle';

--- a/packages/element/src/internal.js
+++ b/packages/element/src/internal.js
@@ -1,6 +1,6 @@
-import {internalChangedCallback as $internalChangedCallback} from '../tokens/lifecycle';
 import {accessor} from '@corpuscule/utils/lib/descriptors';
-import {assertElementProperty} from '../utils';
+import {internalChangedCallback as $internalChangedCallback} from './tokens/lifecycle';
+import {assertElementProperty} from './utils';
 
 const internal = descriptor => {
   assertElementProperty('internal', descriptor);

--- a/packages/element/src/property.js
+++ b/packages/element/src/property.js
@@ -1,6 +1,6 @@
 import {accessor} from '@corpuscule/utils/lib/descriptors';
-import {propertyChangedCallback as $propertyChangedCallback} from '../tokens/lifecycle';
-import {assertElementProperty} from '../utils';
+import {propertyChangedCallback as $propertyChangedCallback} from './tokens/lifecycle';
+import {assertElementProperty} from './utils';
 
 const property = (guard = null) => descriptor => {
   assertElementProperty('property', descriptor);

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -2,7 +2,7 @@
 import {FieldState, FieldValidator, FormApi, FormState} from 'final-form';
 import {createMockedContextElements} from '../../../test/mocks/context';
 import {formSpyObject, unsubscribe} from '../../../test/mocks/finalForm';
-import {CustomElement} from '../../../test/utils';
+import {CustomElement, genName} from '../../../test/utils';
 import {createFormContext, FieldInputProps, FieldMetaProps, FormDecorator} from '../src';
 import {all} from '../src/utils';
 
@@ -312,6 +312,32 @@ const testField = () => {
       subscribeField(fieldElement);
 
       expect(unsubscribe).toHaveBeenCalled();
+    });
+
+    it('executes connectedCallback on real DOM', async () => {
+      const connectedCallbackSpy = jasmine.createSpy('connectedCallback');
+
+      @field
+      class Field extends HTMLElement {
+        @api public readonly form!: FormApi;
+        @api public readonly input!: FieldInputProps<object>;
+        @api public readonly meta!: FieldMetaProps;
+
+        @option public readonly name: string = 'test';
+
+        public connectedCallback(): void {
+          connectedCallbackSpy();
+        }
+      }
+
+      customElements.define(genName(), Field);
+
+      const fieldElement = new Field();
+
+      document.body.appendChild(fieldElement);
+
+      expect(connectedCallbackSpy).toHaveBeenCalled();
+      expect(scheduler).toHaveBeenCalled();
     });
 
     describe('@option', () => {

--- a/packages/form/__tests__/form.ts
+++ b/packages/form/__tests__/form.ts
@@ -360,6 +360,32 @@ const testForm = () => {
       expect(removeEventListener).toHaveBeenCalledWith('submit', fn);
     });
 
+    it('executes connectedCallback on real DOM', async () => {
+      const connectedCallbackSpy = jasmine.createSpy('connectedCallback');
+
+      @form()
+      class Form extends HTMLElement {
+        @api public readonly form!: FormApi;
+        @api public readonly state!: FormState;
+
+        public connectedCallback(): void {
+          connectedCallbackSpy();
+        }
+
+        @option
+        public onSubmit(): void {}
+      }
+
+      customElements.define(genName(), Form);
+
+      const formElement = new Form();
+
+      document.body.appendChild(formElement);
+
+      expect(connectedCallbackSpy).toHaveBeenCalled();
+      expect(formSpyObject.subscribe).toHaveBeenCalled();
+    });
+
     describe('@api', () => {
       it('requires form and state fields defined', () => {
         expect(() => {

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -59,4 +59,6 @@ export const getTargetValue = (
 };
 
 export const filter = elements =>
-  elements.filter(({key, placement}) => !(lifecycleKeys.includes(key) && placement === 'own'));
+  elements.filter(
+    ({key, placement}) => !(lifecycleKeys.includes(key) && placement === 'prototype'),
+  );

--- a/packages/router/__tests__/outlet.ts
+++ b/packages/router/__tests__/outlet.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-classes-per-file
 import UniversalRouter from 'universal-router';
-import {createMockedContextElements} from '../../../test/mocks/context';
-import {createTestingPromise, CustomElement} from '../../../test/utils';
+import {createMockedContextElements, valuesMap} from '../../../test/mocks/context';
+import {createTestingPromise, CustomElement, genName} from '../../../test/utils';
 import {api, outlet, provider} from '../src';
 
 const outletTest = () => {
@@ -244,6 +244,30 @@ const outletTest = () => {
           public disconnectedCallback(): void {} // tslint:disable-line:no-empty
         }
       }).not.toThrow();
+    });
+
+    it('executes connectedCallback on real DOM', async () => {
+      const connectedCallbackSpy = jasmine.createSpy('connectedCallback');
+
+      @outlet(routes)
+      class Outlet extends CustomElement {
+        @api public readonly layout?: string;
+
+        public connectedCallback(): void {
+          connectedCallbackSpy();
+        }
+      }
+
+      customElements.define(genName(), Outlet);
+
+      const outletElement = new Outlet();
+
+      const contextValue = valuesMap.get(Outlet)!;
+      (outletElement as any)[contextValue] = appRouter;
+
+      document.body.appendChild(outletElement);
+      expect(connectedCallbackSpy).toHaveBeenCalled();
+      expect(appRouter.resolve).toHaveBeenCalled();
     });
   });
 };

--- a/packages/router/__tests__/outlet.ts
+++ b/packages/router/__tests__/outlet.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-classes-per-file
 import UniversalRouter from 'universal-router';
 import {createMockedContextElements} from '../../../test/mocks/context';
-import {CustomElement} from '../../../test/utils';
+import {createTestingPromise, CustomElement} from '../../../test/utils';
 import {api, outlet, provider} from '../src';
 
 const outletTest = () => {
@@ -48,13 +48,8 @@ const outletTest = () => {
 
       appRouter.resolve.and.callFake(fakeResolve);
 
-      initialPromise = new Promise(r => {
-        initialResolve = r;
-      });
-
-      finalPromise = new Promise(r => {
-        finalResolve = r;
-      });
+      [initialPromise, initialResolve] = createTestingPromise();
+      [finalPromise, finalResolve] = createTestingPromise();
     });
 
     it('creates router outlet that fills layout on popstate event', async () => {

--- a/packages/utils/__tests__/index.ts
+++ b/packages/utils/__tests__/index.ts
@@ -1,6 +1,7 @@
 import testAsserts from './asserts';
 import testDescriptors from './descriptors';
 import testGetSupers from './getSupers';
+import testLifecycleDescriptors from './lifecycleDescriptors';
 import testPropertyUtils from './propertyUtils';
 import testSchedule from './scheduler';
 import testShallowEqual from './shallowEqual';
@@ -9,6 +10,7 @@ describe('@corpuscule/utils', () => {
   testAsserts();
   testDescriptors();
   testGetSupers();
+  testLifecycleDescriptors();
   testPropertyUtils();
   testSchedule();
   testShallowEqual();

--- a/packages/utils/__tests__/lifecycleDescriptors.ts
+++ b/packages/utils/__tests__/lifecycleDescriptors.ts
@@ -14,7 +14,7 @@ const testLifecycleDescriptors = () => {
       superSpies = jasmine.createSpyObj('supers', ['test']);
 
       constructor = {};
-      result = method({key: 'test', method: methodSpy, supers: superSpies}, constructor);
+      result = method({key: 'test', method: methodSpy}, superSpies, () => constructor);
     });
 
     it('creates method and field descriptors', () => {

--- a/packages/utils/__tests__/lifecycleDescriptors.ts
+++ b/packages/utils/__tests__/lifecycleDescriptors.ts
@@ -1,0 +1,84 @@
+// tslint:disable:no-unnecessary-class
+import {ExtendedPropertyDescriptor} from '@corpuscule/typings';
+import {method} from '../src/lifecycleDescriptors';
+
+const testLifecycleDescriptors = () => {
+  describe('method', () => {
+    let methodSpy: jasmine.Spy;
+    let superSpies: jasmine.SpyObj<{test: Function}>;
+    let constructor: object;
+    let result: [ExtendedPropertyDescriptor, ExtendedPropertyDescriptor];
+
+    beforeEach(() => {
+      methodSpy = jasmine.createSpy('method');
+      superSpies = jasmine.createSpyObj('supers', ['test']);
+
+      constructor = {};
+      result = method({key: 'test', method: methodSpy, supers: superSpies}, constructor);
+    });
+
+    it('creates method and field descriptors', () => {
+      expect(result).toEqual([
+        {
+          descriptor: {
+            configurable: true,
+            enumerable: true,
+            value: jasmine.any(Function),
+            writable: true,
+          },
+          extras: undefined,
+          finisher: undefined,
+          key: 'test',
+          kind: 'method',
+          placement: 'prototype',
+        },
+        {
+          descriptor: {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+          },
+          extras: undefined,
+          finisher: undefined,
+          initializer: jasmine.any(Function),
+          key: jasmine.any(Symbol) as any,
+          kind: 'field',
+          placement: 'own',
+        },
+      ]);
+    });
+
+    it('runs "method" if class constructor is equal to "constructor" param and "super" if not', () => {
+      const withConstructor = {constructor};
+      const initialized = result[1].initializer!.call(withConstructor) as Function;
+
+      initialized();
+
+      expect(methodSpy).toHaveBeenCalled();
+
+      const withoutConstructor = {};
+      const initialized2 = result[1].initializer!.call(withoutConstructor) as Function;
+
+      initialized2();
+
+      expect(superSpies.test).toHaveBeenCalled();
+    });
+
+    it("calls class element with field's key if method is called", () => {
+      const fieldElementSpy = jasmine.createSpy('field');
+
+      const obj = {
+        [result[1].key]: fieldElementSpy,
+      };
+
+      const probe1 = Symbol();
+      const probe2 = Symbol();
+
+      result[0].descriptor.value.call(obj, probe1, probe2);
+
+      expect(fieldElementSpy).toHaveBeenCalledWith(probe1, probe2);
+    });
+  });
+};
+
+export default testLifecycleDescriptors;

--- a/packages/utils/src/lifecycleDescriptors.d.ts
+++ b/packages/utils/src/lifecycleDescriptors.d.ts
@@ -2,10 +2,10 @@ import {ExtendedPropertyDescriptor} from '@corpuscule/typings';
 
 export type LifecycleMethodParams = Pick<ExtendedPropertyDescriptor, 'key'> & {
   readonly method: Function;
-  readonly supers: Record<PropertyKey, Function>;
 };
 
 export const method: (
   params: LifecycleMethodParams,
-  constructor: unknown,
+  supers: Record<PropertyKey, Function>,
+  constructor: () => unknown,
 ) => [ExtendedPropertyDescriptor, ExtendedPropertyDescriptor];

--- a/packages/utils/src/lifecycleDescriptors.d.ts
+++ b/packages/utils/src/lifecycleDescriptors.d.ts
@@ -1,0 +1,11 @@
+import {ExtendedPropertyDescriptor} from '@corpuscule/typings';
+
+export type LifecycleMethodParams = Pick<ExtendedPropertyDescriptor, 'key'> & {
+  readonly method: Function;
+  readonly supers: Record<PropertyKey, Function>;
+};
+
+export const method: (
+  params: LifecycleMethodParams,
+  constructor: unknown,
+) => [ExtendedPropertyDescriptor, ExtendedPropertyDescriptor];

--- a/packages/utils/src/lifecycleDescriptors.js
+++ b/packages/utils/src/lifecycleDescriptors.js
@@ -1,0 +1,20 @@
+import {field, method as mmethod} from './descriptors';
+
+export const method = ({key, method: value, supers}, constructor) => {
+  const $$key = Symbol();
+
+  return [
+    mmethod({
+      key,
+      method(...args) {
+        this[$$key](...args);
+      },
+    }),
+    field({
+      initializer() {
+        return this.constructor === constructor ? value : supers[key];
+      },
+      key: $$key,
+    }),
+  ];
+};

--- a/packages/utils/src/lifecycleDescriptors.js
+++ b/packages/utils/src/lifecycleDescriptors.js
@@ -1,6 +1,6 @@
 import {field, method as mmethod} from './descriptors';
 
-export const method = ({key, method: value, supers}, constructor) => {
+export const method = ({key, method: value}, supers, getConstructor) => {
   const $$key = Symbol();
 
   return [
@@ -12,7 +12,7 @@ export const method = ({key, method: value, supers}, constructor) => {
     }),
     field({
       initializer() {
-        return this.constructor === constructor ? value : supers[key];
+        return this.constructor === getConstructor() ? value : supers[key];
       },
       key: $$key,
     }),

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -11,6 +11,7 @@ const packages = {
     'compose',
     'descriptors',
     'getSupers',
+    'lifecycleDescriptors',
     'propertyUtils',
     'scheduler',
     'shallowEqual',

--- a/test/mocks/context.ts
+++ b/test/mocks/context.ts
@@ -5,13 +5,13 @@ import {Constructor, CustomElement, genName} from '../utils';
 
 export const context = jasmine.createSpyObj('context', ['consumer', 'provider', 'value']);
 
-const values: WeakMap<object, string> = new WeakMap();
+export const valuesMap: WeakMap<object, string> = new WeakMap();
 
 context.value.and.callFake(
   ({descriptor: {get, set}, initializer, key}: ExtendedPropertyDescriptor) =>
     accessor({
       finisher(target: object): void {
-        values.set(target, key as string);
+        valuesMap.set(target, key as string);
       },
       get,
       initializer,
@@ -39,14 +39,14 @@ export const createMockedContextElements = <T extends CustomElement[]>(
 
   const consumers = new Array(consumerConstructors.length);
   const provider = new providerConstructor();
-  const providingValue = values.get(providerConstructor)!;
+  const providingValue = valuesMap.get(providerConstructor)!;
 
   // tslint:disable-next-line:no-increment-decrement
   for (let i = 0; i < consumerConstructors.length; i++) {
     customElements.define(genName(), consumerConstructors[i]);
     consumers[i] = new consumerConstructors[i]();
 
-    const contextValue = values.get(consumerConstructors[i])!;
+    const contextValue = valuesMap.get(consumerConstructors[i])!;
     consumers[i][contextValue] = (provider as any)[providingValue];
   }
 
@@ -66,7 +66,7 @@ export const createMockedContextElements = <T extends CustomElement[]>(
 
         // tslint:disable-next-line:no-increment-decrement
         for (let i = 0; i < consumers.length; i++) {
-          const contextValue = values.get(consumerConstructors[i])!;
+          const contextValue = valuesMap.get(consumerConstructors[i])!;
           consumers[i][contextValue] = value;
         }
       },


### PR DESCRIPTION
This PR fixes many issues appeared. The most important one is the issue when Corpuscule `connectedCallback` does not fire. It happens because the basic idea was to make Corpuscule implementation of `connectedCallback` `own` class element. Unfortunately, spec takes only `connectedCallback` defined as `method` on `prototype`, so initial implementation was wrong and doesn't work.

This trick is necessary to solve the problem described in #24. So, now inheritance indication is based on comparing constructor of `this` and constructor remembered by decorator. If they are different, element is inherited. It means that it can disable all Corpuscule system elements and only provide user-defined methods. `lifecycleDecorators` is introduced to help with this. 