### PR TITLE
Fix couple of mistakes

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -299,6 +299,9 @@ Creator function returns an `@element` decorator function that receives followin
   * `extends?: keyof HTMLElementTagNameMap`. This parameter allows to create a
   [Customized Built-In Element](#customized-builtin-element) instead of a regular Custom Element.
 
+**Note**: `@element` decorator should go **ON TOP** of all other decorators. Otherwise, you could expect strange errors
+happening.
+
 ##### Example
 ```javascript
 import {createElementDecorator, render} from '@corpuscule/element';

--- a/packages/element/src/element.js
+++ b/packages/element/src/element.js
@@ -203,11 +203,7 @@ const createElementDecorator = ({renderer, scheduler = defaultScheduler}) => (
 
       constructor = target;
 
-      // Registry creates an instance of the class, so it is necessary to wait
-      // unit all finishers are called
-      Promise.resolve().then(() => {
-        customElements.define(name, target, builtin && {extends: builtin});
-      });
+      customElements.define(name, target, builtin && {extends: builtin});
     },
     kind,
   };

--- a/packages/element/src/element.js
+++ b/packages/element/src/element.js
@@ -203,7 +203,11 @@ const createElementDecorator = ({renderer, scheduler = defaultScheduler}) => (
 
       constructor = target;
 
-      customElements.define(name, target, builtin && {extends: builtin});
+      // Registry creates an instance of the class, so it is necessary to wait
+      // unit all finishers are called
+      Promise.resolve().then(() => {
+        customElements.define(name, target, builtin && {extends: builtin});
+      });
     },
     kind,
   };

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-unbound-method no-empty
 import {FieldState, FieldValidator, FormApi, FormState} from 'final-form';
-import {createMockedContextElements} from '../../../test/mocks/context';
+import {createMockedContextElements, finisher} from '../../../test/mocks/context';
 import {formSpyObject, unsubscribe} from '../../../test/mocks/finalForm';
 import {CustomElement, genName} from '../../../test/utils';
 import {createFormContext, FieldInputProps, FieldMetaProps, FormDecorator} from '../src';
@@ -88,6 +88,7 @@ const testField = () => {
       expect(fieldElement.form).toBe(formSpyObject);
       expect(formSpyObject.subscribe).toHaveBeenCalled();
       expect(scheduler).toHaveBeenCalledWith(jasmine.any(Function));
+      expect(finisher).toHaveBeenCalledWith(FormField);
     });
 
     it('subscribes to form with defined options', () => {

--- a/packages/form/__tests__/form.ts
+++ b/packages/form/__tests__/form.ts
@@ -1,5 +1,6 @@
 // tslint:disable:no-unused-expression no-empty
 import {FormApi, FormState} from 'final-form';
+import {finisher} from '../../../test/mocks/context';
 import {createForm, formSpyObject, unsubscribe} from '../../../test/mocks/finalForm';
 import {CustomElement, genName} from '../../../test/utils';
 import {createFormContext, FormDecorator} from '../src';
@@ -42,6 +43,8 @@ const testForm = () => {
         debug: true,
         onSubmit: jasmine.any(Function),
       });
+
+      expect(finisher).toHaveBeenCalledWith(Test);
     });
 
     it('allows to declare configuration with method and makes it bound', () => {

--- a/packages/form/src/api.js
+++ b/packages/form/src/api.js
@@ -16,9 +16,12 @@ const createApiDecorator = ({value}, {api}, {input, meta}, {state}) => descripto
     throw new TypeError(`Property name ${name} is not allowed`);
   }
 
+  const {extras = [], ...finalDescriptor} = isFormApi ? value(descriptor) : descriptor;
+
   return {
-    ...(isFormApi ? value(descriptor) : descriptor),
+    ...finalDescriptor,
     extras: [
+      ...extras,
       hook({
         start() {
           if (isFormApi) {

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -40,7 +40,7 @@ const createField = (
   const $$update = Symbol();
   const $$updatingValid = Symbol();
 
-  const {elements, kind} = consumer(descriptor);
+  const {elements, finisher: consumerFinisher, kind} = consumer(descriptor);
   const [supers, prepareSupers] = getSupers(elements, $.lifecycleKeys);
 
   return {
@@ -198,6 +198,7 @@ const createField = (
     ],
     finisher(target) {
       prepareSupers(target);
+      consumerFinisher(target);
 
       constructor = target;
 

--- a/packages/form/src/form.js
+++ b/packages/form/src/form.js
@@ -24,7 +24,7 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
   const $$submit = Symbol();
   const $$unsubscriptions = Symbol();
 
-  const {elements, kind} = provider(descriptor);
+  const {elements, finisher: providerFinisher, kind} = provider(descriptor);
 
   const [supers, prepareSupers] = getSupers(elements, lifecycleKeys);
 
@@ -119,6 +119,7 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
     ],
     finisher(target) {
       prepareSupers(target);
+      providerFinisher(target);
 
       constructor = target;
 

--- a/packages/redux/__tests__/index.ts
+++ b/packages/redux/__tests__/index.ts
@@ -1,6 +1,6 @@
 // tslint:disable:max-classes-per-file
 import {AnyAction, Store} from 'redux';
-import {createMockedContextElements, valuesMap} from '../../../test/mocks/context';
+import {createMockedContextElements, finisher, valuesMap} from '../../../test/mocks/context';
 import {CustomElement, genName} from '../../../test/utils';
 import {api, dispatcher, provider, redux, unit} from '../src';
 
@@ -18,7 +18,7 @@ describe('@corpuscule/redux', () => {
   });
 
   describe('@redux', () => {
-    it('subscribes to store', () => {
+    it('creates element that subscribes to a store', () => {
       @provider
       class Provider extends CustomElement {
         @api public store: Store = reduxStore;
@@ -30,6 +30,7 @@ describe('@corpuscule/redux', () => {
       createMockedContextElements(Provider, Connected);
 
       expect(reduxStore.subscribe).toHaveBeenCalled();
+      expect(finisher).toHaveBeenCalledWith(Connected);
     });
 
     it('unsubscribes from store before subscribing to a new one', () => {

--- a/packages/redux/src/redux.js
+++ b/packages/redux/src/redux.js
@@ -9,7 +9,7 @@ const [, disconnectedCallbackKey] = lifecycleKeys;
 export const createReduxDecorator = ({consumer, value}, {units}, {store}) => descriptor => {
   assertKind('connect', Kind.Class, descriptor);
 
-  const {elements, kind} = consumer(descriptor);
+  const {elements, finisher: consumerFinisher, kind} = consumer(descriptor);
 
   let constructor;
   let unitMap;
@@ -107,6 +107,7 @@ export const createReduxDecorator = ({consumer, value}, {units}, {store}) => des
       }),
     ],
     finisher(target) {
+      consumerFinisher(target);
       constructor = target;
       unitMap = units.get(target);
       finish(target);

--- a/packages/router/__tests__/outlet.ts
+++ b/packages/router/__tests__/outlet.ts
@@ -1,6 +1,6 @@
 // tslint:disable:max-classes-per-file
 import UniversalRouter from 'universal-router';
-import {createMockedContextElements, valuesMap} from '../../../test/mocks/context';
+import {createMockedContextElements, finisher, valuesMap} from '../../../test/mocks/context';
 import {createTestingPromise, CustomElement, genName} from '../../../test/utils';
 import {api, outlet, provider} from '../src';
 
@@ -85,6 +85,7 @@ const outletTest = () => {
       await initialPromise;
 
       expect(outletElement.layout).toBe('Test');
+      expect(finisher).toHaveBeenCalledWith(Outlet);
 
       window.dispatchEvent(
         new PopStateEvent('popstate', {

--- a/packages/router/src/outlet.js
+++ b/packages/router/src/outlet.js
@@ -12,7 +12,7 @@ const [connectedCallbackKey, disconnectedCallbackKey] = lifecycleKeys;
 const createOutletDecorator = ({consumer, value}, {api}) => routes => descriptor => {
   assertKind('outlet', Kind.Class, descriptor);
 
-  const {elements, kind} = consumer(descriptor);
+  const {elements, finisher: consumerFinisher, kind} = consumer(descriptor);
 
   let constructor;
   let $api;
@@ -23,7 +23,7 @@ const createOutletDecorator = ({consumer, value}, {api}) => routes => descriptor
   const $$updateRoute = Symbol();
 
   const [supers, finish] = getSupers(elements, methods);
-  const {extras, finisher: contextFinisher, ...contextValueDescriptor} = value(
+  const {extras, finisher: contextValueFinisher, ...contextValueDescriptor} = value(
     field({key: $$contextValue}),
   );
 
@@ -94,6 +94,8 @@ const createOutletDecorator = ({consumer, value}, {api}) => routes => descriptor
       }),
     ],
     finisher(target) {
+      consumerFinisher(target);
+
       constructor = target;
       $api = api.get(target);
       assertRequiredProperty('outlet', 'api', $api);
@@ -104,7 +106,7 @@ const createOutletDecorator = ({consumer, value}, {api}) => routes => descriptor
         },
       });
 
-      contextFinisher(target);
+      contextValueFinisher(target);
     },
     kind,
   };

--- a/test/mocks/context.ts
+++ b/test/mocks/context.ts
@@ -4,6 +4,7 @@ import {accessor} from '../../packages/utils/src/descriptors';
 import {Constructor, CustomElement, genName} from '../utils';
 
 export const context = jasmine.createSpyObj('context', ['consumer', 'provider', 'value']);
+export const finisher = jasmine.createSpy('context.finisher');
 
 export const valuesMap: WeakMap<object, string> = new WeakMap();
 
@@ -20,10 +21,13 @@ context.value.and.callFake(
     }),
 );
 
-const identity = <T>(descriptor: T) => descriptor;
+const fakeDecorator = <T>(descriptor: T) => ({
+  ...descriptor,
+  finisher,
+});
 
-context.consumer.and.callFake(identity);
-context.provider.and.callFake(identity);
+context.consumer.and.callFake(fakeDecorator);
+context.provider.and.callFake(fakeDecorator);
 
 const createContext = jasmine.createSpy('createContext');
 createContext.and.returnValue(context);


### PR DESCRIPTION
This PR fixes a couple of issues:
* If `@element` is placed before others, everything may fail because of `customElements.define` which creates an instance of the element when other finishers are not called yet. Fix: put custom element definition into an event loop to make sure it will start after all other synchronous code.
* Derivatives of `@corpuscule/context` don't call its finishers. This PR fixes this mistake as well.