### PR TITLE
Travis: remove unnecessary node instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ dist: trusty
 addons:
   chrome: stable
 node_js:
-  - '11'
   - '10'
-  - '8'
 cache:
   directories:
   - $HOME/.npm


### PR DESCRIPTION
Since everything regarding framework is performed at Chrome, there is no reason to keep three node instances for tests.