### PR TITLE
Add query and queryAll decorators

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -402,6 +402,48 @@ class MySquareInfo extends HTMLElement {
 }
 ```
 
+#### `@query`
+Decorator that allows to transform property to a getter that performs `querySelector` action on
+the Custom Element's root: `ShadowRoot` or `this` depending on what kind of DOM was chosen.
+
+#### Example
+```javascript
+@element('my-element')
+class MyElement extends HTMLElement {
+  @query('#target') target;
+  
+  [render]() {
+    return html`
+      <div class="wrapper">
+        <span id="target"></span>
+      </div>
+    `;
+  }
+}
+```
+
+#### `@queryAll`
+Decorator that allows to transform property to a getter that performs `querySelectorAll` action on
+the Custom Element's root: `ShadowRoot` or `this` depending on what kind of DOM was chosen.
+
+#### Example
+```javascript
+@element('my-element')
+class MyElement extends HTMLElement {
+  @queryAll('.target') targets;
+  
+  [render]() {
+    return html`
+      <div class="wrapper">
+        <span class="target"></span>
+        <span class="target"></span>
+        <span class="target"></span>
+      </div>
+    `;
+  }
+}
+```
+
 #### `createComputingPair(): ComputingPair`
 Function creates an object that contains a pair of bound decorators, `@observer` and `@computer`
 that could be used to create computed properties.

--- a/packages/element/__tests__/index.ts
+++ b/packages/element/__tests__/index.ts
@@ -3,6 +3,7 @@ import testComputingPair from './computingPair';
 import testElementDecorator from './element';
 import testInternalDecorator from './internal';
 import testPropertyDecorator from './property';
+import testQuery from './query';
 
 describe('@corpuscule/element', () => {
   testAttributeDecorator();
@@ -10,4 +11,5 @@ describe('@corpuscule/element', () => {
   testElementDecorator();
   testPropertyDecorator();
   testInternalDecorator();
+  testQuery();
 });

--- a/packages/element/__tests__/query.ts
+++ b/packages/element/__tests__/query.ts
@@ -1,0 +1,122 @@
+import {defineCE, fixture} from '@open-wc/testing-helpers';
+import {query, queryAll} from '../src';
+
+const testQuery = () => {
+  describe('@query', () => {
+    it('finds element in shadow root', async () => {
+      class Test extends HTMLElement {
+        @query('#target')
+        public target!: HTMLElement;
+
+        public constructor() {
+          super();
+
+          this.attachShadow({mode: 'open'});
+        }
+
+        public connectedCallback(): void {
+          // tslint:disable-next-line:no-inner-html
+          this.shadowRoot!.innerHTML = `
+            <div></div>
+            <div class="wrapper">
+              <div id="target">Test text</div>
+            </div>
+          `;
+        }
+      }
+
+      const tag = defineCE(Test);
+      const test = (await fixture(`<${tag}></${tag}>`)) as Test;
+
+      expect(test.target).toEqual(jasmine.any(HTMLElement));
+      expect(test.target.textContent).toBe('Test text');
+    });
+
+    it('finds element in lightDOM', async () => {
+      class Test extends HTMLElement {
+        @query('#target')
+        public target!: HTMLElement;
+
+        public connectedCallback(): void {
+          // tslint:disable-next-line:no-inner-html
+          this.innerHTML = `
+            <div></div>
+            <div class="wrapper">
+              <div id="target">Test text</div>
+            </div>
+          `;
+        }
+      }
+
+      const tag = defineCE(Test);
+      const test = (await fixture(`<${tag}></${tag}>`)) as Test;
+
+      expect(test.target).toEqual(jasmine.any(HTMLElement));
+      expect(test.target.textContent).toBe('Test text');
+    });
+  });
+
+  describe('@queryAll', () => {
+    it('finds all elements in shadow root', async () => {
+      class Test extends HTMLElement {
+        @queryAll('.target')
+        public targets!: HTMLElement;
+
+        public constructor() {
+          super();
+
+          this.attachShadow({mode: 'open'});
+        }
+
+        public connectedCallback(): void {
+          // tslint:disable-next-line:no-inner-html
+          this.shadowRoot!.innerHTML = `
+            <div></div>
+            <div class="wrapper">
+              <div class="target">Test 1</div>
+              <div class="target">Test 2</div>
+              <div class="target">Test 3</div>
+            </div>
+          `;
+        }
+      }
+
+      const tag = defineCE(Test);
+      const test = (await fixture(`<${tag}></${tag}>`)) as Test;
+
+      expect(test.targets).toEqual(jasmine.any(NodeList));
+      expect(test.targets[0].textContent).toBe('Test 1');
+      expect(test.targets[1].textContent).toBe('Test 2');
+      expect(test.targets[2].textContent).toBe('Test 3');
+    });
+
+    it('finds all elements in light DOM', async () => {
+      class Test extends HTMLElement {
+        @queryAll('.target')
+        public targets!: HTMLElement;
+
+        public connectedCallback(): void {
+          // tslint:disable-next-line:no-inner-html
+          this.innerHTML = `
+            <div></div>
+            <div class="wrapper">
+              <div class="target">Test 1</div>
+              <div class="target">Test 2</div>
+              <div class="target">Test 3</div>
+            </div>
+          `;
+        }
+      }
+
+      const tag = defineCE(Test);
+      const test = (await fixture(`<${tag}></${tag}>`)) as Test;
+
+      expect(test.targets).toEqual(jasmine.any(NodeList));
+      expect(test.targets[0].textContent).toBe('Test 1');
+      expect(test.targets[1].textContent).toBe('Test 2');
+      expect(test.targets[2].textContent).toBe('Test 3');
+    });
+  });
+};
+
+export default testQuery;

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -32,6 +32,9 @@ export const property: (guard?: PropertyGuard) => PropertyDecorator;
 
 export const createComputingPair: () => ComputingPair;
 
+export const query: (selector: string) => PropertyDecorator;
+export const queryAll: (selector: string) => PropertyDecorator;
+
 export const internalChangedCallback: unique symbol;
 export const propertyChangedCallback: unique symbol;
 export const render: unique symbol;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -4,3 +4,4 @@ export {default as createElementDecorator} from './element';
 export {default as internal} from './internal';
 export {default as property} from './property';
 export * from './tokens/lifecycle';
+export * from './query';

--- a/packages/element/src/query.js
+++ b/packages/element/src/query.js
@@ -1,0 +1,21 @@
+import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
+import {accessor} from '@corpuscule/utils/lib/descriptors';
+
+const createQuery = (name, callback) => selector => descriptor => {
+  assertKind(name, Kind.Field, descriptor);
+  assertPlacement(name, Placement.Own, descriptor);
+
+  const {key} = descriptor;
+
+  return accessor({
+    get() {
+      return callback(this.shadowRoot || this, selector);
+    },
+    key,
+  });
+};
+
+export const query = createQuery('query', (target, selector) => target.querySelector(selector));
+export const queryAll = createQuery('queryAll', (target, selector) =>
+  target.querySelectorAll(selector),
+);


### PR DESCRIPTION
This PR introduces `@query` and `@queryAll` decorators that allow searching elements in the Custom Element root. 

#### Example
```javascript
@element('my-element')
class MyElement extends HTMLElement {
  @query('#target') target;
  
  [render]() {
    return html`
      <div class="wrapper">
        <span id="target"></span>
      </div>
    `;
  }
}
```