### PR TITLE
Allow decorators to be wrappers

### DIFF
--- a/packages/context/__tests__/index.ts
+++ b/packages/context/__tests__/index.ts
@@ -289,13 +289,13 @@ describe('@corpuscule/context', () => {
         @provider
         // @ts-ignore
         class Provider extends CustomElement {}
-      }).toThrowError('No Provider field is marked with @value');
+      }).toThrowError('@provider requires any property marked with @value');
 
       expect(() => {
         @consumer
         // @ts-ignore
         class Consumer extends CustomElement {}
-      }).toThrowError('No Consumer field is marked with @value');
+      }).toThrowError('@consumer requires any property marked with @value');
     });
 
     it('does not throw an error if class already have own lifecycle element', () => {

--- a/packages/context/src/consumer.js
+++ b/packages/context/src/consumer.js
@@ -3,7 +3,7 @@ import getSupers from '@corpuscule/utils/lib/getSupers';
 import {lifecycleKeys, method} from '@corpuscule/utils/lib/descriptors';
 import {method as lifecycleMethod} from '@corpuscule/utils/lib/lifecycleDescriptors';
 import {setValue} from '@corpuscule/utils/lib/propertyUtils';
-import {filter} from './utils';
+import {filter, noop} from './utils';
 
 const createConsumer = (
   {eventName, value},
@@ -11,7 +11,7 @@ const createConsumer = (
 ) => descriptor => {
   assertKind('consumer', Kind.Class, descriptor);
 
-  const {elements, kind} = descriptor;
+  const {elements, finisher = noop, kind} = descriptor;
 
   let constructor;
   let $value;
@@ -25,8 +25,6 @@ const createConsumer = (
 
   return {
     elements: [
-      ...filter(elements),
-
       // Public
       ...lifecycleMethod(
         {
@@ -76,11 +74,14 @@ const createConsumer = (
           setValue(this, $value, v);
         },
       }),
+
+      ...filter(elements),
     ],
     finisher(target) {
+      finisher(target);
       constructor = target;
-      $value = value.get(target);
 
+      $value = value.get(target);
       assertRequiredProperty('consumer', 'value', $value);
 
       prepareSupers(target);

--- a/packages/context/src/consumer.js
+++ b/packages/context/src/consumer.js
@@ -75,6 +75,7 @@ const createConsumer = (
         },
       }),
 
+      // Original elements
       ...filter(elements),
     ],
     finisher(target) {

--- a/packages/context/src/consumer.js
+++ b/packages/context/src/consumer.js
@@ -3,7 +3,7 @@ import getSupers from '@corpuscule/utils/lib/getSupers';
 import {lifecycleKeys, method} from '@corpuscule/utils/lib/descriptors';
 import {method as lifecycleMethod} from '@corpuscule/utils/lib/lifecycleDescriptors';
 import {setValue} from '@corpuscule/utils/lib/propertyUtils';
-import {checkValue, filter} from './utils';
+import {filter} from './utils';
 
 const createConsumer = (
   {eventName, value},
@@ -78,8 +78,6 @@ const createConsumer = (
       }),
     ],
     finisher(target) {
-      checkValue(value, target);
-
       constructor = target;
       $value = value.get(target);
 

--- a/packages/context/src/provider.js
+++ b/packages/context/src/provider.js
@@ -3,7 +3,7 @@ import getSupers from '@corpuscule/utils/lib/getSupers';
 import {field, hook, lifecycleKeys, method} from '@corpuscule/utils/lib/descriptors';
 import {method as lifecycleMethod} from '@corpuscule/utils/lib/lifecycleDescriptors';
 import {getValue, setValue} from '@corpuscule/utils/lib/propertyUtils';
-import {filter} from './utils';
+import {filter, noop} from './utils';
 
 const createProvider = (
   {consumers, eventName, providers, value},
@@ -12,7 +12,7 @@ const createProvider = (
 ) => descriptor => {
   assertKind('provider', Kind.Class, descriptor);
 
-  const {elements, kind} = descriptor;
+  const {elements, finisher = noop, kind} = descriptor;
 
   let constructor;
   let $value;
@@ -27,8 +27,6 @@ const createProvider = (
 
   return {
     elements: [
-      ...filter(elements),
-
       // Public
       ...lifecycleMethod(
         {
@@ -79,6 +77,9 @@ const createProvider = (
         },
       }),
 
+      // Original elements
+      ...filter(elements),
+
       // Hooks
       hook({
         start() {
@@ -96,12 +97,13 @@ const createProvider = (
       }),
     ],
     finisher(target) {
-      prepareSupers(target);
+      finisher(target);
       constructor = target;
 
       $value = value.get(target);
-
       assertRequiredProperty('provider', 'value', $value);
+
+      prepareSupers(target);
     },
     kind,
   };

--- a/packages/context/src/provider.js
+++ b/packages/context/src/provider.js
@@ -3,7 +3,7 @@ import getSupers from '@corpuscule/utils/lib/getSupers';
 import {field, hook, lifecycleKeys, method} from '@corpuscule/utils/lib/descriptors';
 import {method as lifecycleMethod} from '@corpuscule/utils/lib/lifecycleDescriptors';
 import {getValue, setValue} from '@corpuscule/utils/lib/propertyUtils';
-import {checkValue, filter} from './utils';
+import {filter} from './utils';
 
 const createProvider = (
   {consumers, eventName, providers, value},
@@ -96,7 +96,6 @@ const createProvider = (
       }),
     ],
     finisher(target) {
-      checkValue(value, target);
       prepareSupers(target);
       constructor = target;
 

--- a/packages/context/src/utils.js
+++ b/packages/context/src/utils.js
@@ -1,5 +1,8 @@
 import {lifecycleKeys} from '@corpuscule/utils/lib/descriptors';
 
+// eslint-disable-next-line no-empty-function
+export const noop = () => {};
+
 export const filter = elements =>
   elements.filter(
     ({key, placement}) => !(lifecycleKeys.includes(key) && placement === 'prototype'),

--- a/packages/context/src/utils.js
+++ b/packages/context/src/utils.js
@@ -1,11 +1,5 @@
 import {lifecycleKeys} from '@corpuscule/utils/lib/descriptors';
 
-export const checkValue = (value, target) => {
-  if (!value.has(target)) {
-    throw new Error(`No ${target.name} field is marked with @value`);
-  }
-};
-
 export const filter = elements =>
   elements.filter(
     ({key, placement}) => !(lifecycleKeys.includes(key) && placement === 'prototype'),

--- a/packages/context/src/value.js
+++ b/packages/context/src/value.js
@@ -1,5 +1,6 @@
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
 import {accessor, hook} from '@corpuscule/utils/lib/descriptors';
+import {noop} from './utils';
 
 const createValue = ({consumers, value, providers}) => descriptor => {
   assertKind('value', Kind.Field | Kind.Method | Kind.Accessor, descriptor);
@@ -7,6 +8,8 @@ const createValue = ({consumers, value, providers}) => descriptor => {
 
   const {
     descriptor: {get, set},
+    extras = [],
+    finisher = noop,
     initializer,
     key,
   } = descriptor;
@@ -33,10 +36,12 @@ const createValue = ({consumers, value, providers}) => descriptor => {
           value.set(this, key);
         },
       }),
+      ...extras,
     ],
     finisher(target) {
       isProvider = providers.has(target);
       $$consumers = consumers.get(target);
+      finisher(target);
     },
     get,
     initializer() {

--- a/packages/element/src/attribute.js
+++ b/packages/element/src/attribute.js
@@ -1,5 +1,6 @@
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
 import {accessor} from '@corpuscule/utils/lib/descriptors';
+import {noop} from './utils';
 
 const attribute = (name, guard) => descriptor => {
   assertKind('attribute', Kind.Field, descriptor);
@@ -9,11 +10,13 @@ const attribute = (name, guard) => descriptor => {
     throw new TypeError('Guard for @attribute should be either Number, Boolean or String');
   }
 
-  const {key} = descriptor;
+  const {extras, finisher = noop, key} = descriptor;
   const guardType = typeof guard(null);
 
   return accessor({
+    extras,
     finisher(target) {
+      finisher(target);
       target.observedAttributes.push(name);
     },
     get() {

--- a/packages/element/src/computingPair.js
+++ b/packages/element/src/computingPair.js
@@ -1,6 +1,6 @@
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
 import {accessor, field} from '@corpuscule/utils/lib/descriptors';
-import {assertElementProperty} from './utils';
+import {assertElementProperty, noop} from './utils';
 
 const createComputingPair = () => {
   const registry = new WeakMap();
@@ -11,6 +11,8 @@ const createComputingPair = () => {
 
     const {
       descriptor: {get},
+      extras = [],
+      finisher = noop,
       key,
     } = descriptor;
 
@@ -26,8 +28,11 @@ const createComputingPair = () => {
           initializer: () => false,
           key: correct,
         }),
+        ...extras,
       ],
       finisher(target) {
+        finisher(target);
+
         if (registry.has(target)) {
           registry.get(target).push(correct);
         } else {
@@ -51,6 +56,8 @@ const createComputingPair = () => {
 
     const {
       descriptor: {get, set},
+      extras,
+      finisher = noop,
       initializer,
       key,
     } = descriptor;
@@ -68,6 +75,8 @@ const createComputingPair = () => {
           },
         };
       },
+      extras,
+      finisher,
       get,
       initializer,
       key,

--- a/packages/element/src/internal.js
+++ b/packages/element/src/internal.js
@@ -1,12 +1,14 @@
 import {accessor} from '@corpuscule/utils/lib/descriptors';
 import {internalChangedCallback as $internalChangedCallback} from './tokens/lifecycle';
-import {assertElementProperty} from './utils';
+import {assertElementProperty, noop} from './utils';
 
 const internal = descriptor => {
   assertElementProperty('internal', descriptor);
 
   const {
     descriptor: {get, set},
+    extras,
+    finisher = noop,
     initializer,
     key,
   } = descriptor;
@@ -19,6 +21,8 @@ const internal = descriptor => {
         originalSet.call(this, value);
       },
     }),
+    extras,
+    finisher,
     get,
     initializer,
     key,

--- a/packages/element/src/property.js
+++ b/packages/element/src/property.js
@@ -1,12 +1,14 @@
 import {accessor} from '@corpuscule/utils/lib/descriptors';
 import {propertyChangedCallback as $propertyChangedCallback} from './tokens/lifecycle';
-import {assertElementProperty} from './utils';
+import {assertElementProperty, noop} from './utils';
 
 const property = (guard = null) => descriptor => {
   assertElementProperty('property', descriptor);
 
   const {
     descriptor: {get, set},
+    extras,
+    finisher = noop,
     initializer,
     key,
   } = descriptor;
@@ -23,6 +25,8 @@ const property = (guard = null) => descriptor => {
         originalSet.call(this, value);
       },
     }),
+    extras,
+    finisher,
     get,
     initializer,
     key,

--- a/packages/element/src/query.js
+++ b/packages/element/src/query.js
@@ -1,13 +1,16 @@
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
 import {accessor} from '@corpuscule/utils/lib/descriptors';
+import {noop} from './utils';
 
 const createQuery = (name, callback) => selector => descriptor => {
   assertKind(name, Kind.Field, descriptor);
   assertPlacement(name, Placement.Own, descriptor);
 
-  const {key} = descriptor;
+  const {extras, finisher = noop, key} = descriptor;
 
   return accessor({
+    extras,
+    finisher,
     get() {
       return callback(this.shadowRoot || this, selector);
     },

--- a/packages/element/src/utils.js
+++ b/packages/element/src/utils.js
@@ -1,5 +1,8 @@
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
 
+// eslint-disable-next-line no-empty-function
+export const noop = () => {};
+
 export const assertElementProperty = (decoratorName, descriptor) => {
   assertKind(decoratorName, Kind.Field | Kind.Accessor, descriptor);
   assertPlacement(decoratorName, Placement.Own | Placement.Prototype, descriptor);

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -95,6 +95,36 @@ const testField = () => {
       expect(scheduler).toHaveBeenCalledWith(jasmine.any(Function));
     });
 
+    it('receives form before user-defined connectedCallback is run', async () => {
+      const connectedCallbackSpy = jasmine.createSpy('connectedCallback');
+
+      @form()
+      class Form extends CustomElement {
+        @api public readonly form!: FormApi;
+        @api public readonly state!: FormState;
+
+        @option
+        public onSubmit(): void {}
+      }
+
+      @field
+      class Field extends CustomElement {
+        @api public readonly form!: FormApi;
+        @api public readonly input!: FieldInputProps<string>;
+        @api public readonly meta!: FieldMetaProps;
+
+        @option public readonly name: string = 'test';
+
+        public connectedCallback(): void {
+          connectedCallbackSpy(this.form);
+        }
+      }
+
+      await createSimpleContext(Form, Field);
+
+      expect(connectedCallbackSpy).toHaveBeenCalledWith(formSpyObject);
+    });
+
     it('subscribes to form with defined options', async () => {
       @form()
       class Form extends CustomElement {

--- a/packages/form/src/api.js
+++ b/packages/form/src/api.js
@@ -7,7 +7,7 @@ const createApiDecorator = ({value}, {api}, {input, meta}, {state}) => descripto
   assertKind('api', Kind.Field | Kind.Accessor, descriptor);
   assertPlacement('api', Placement.Own | Placement.Prototype, descriptor);
 
-  const {key} = descriptor;
+  const {extras = [], key} = descriptor;
   const name = getName(key);
 
   const isFormApi = name === 'form';
@@ -16,12 +16,9 @@ const createApiDecorator = ({value}, {api}, {input, meta}, {state}) => descripto
     throw new TypeError(`Property name ${name} is not allowed`);
   }
 
-  const {extras = [], ...finalDescriptor} = isFormApi ? value(descriptor) : descriptor;
-
-  return {
-    ...finalDescriptor,
+  const finalDescriptor = {
+    ...descriptor,
     extras: [
-      ...extras,
       hook({
         start() {
           if (isFormApi) {
@@ -32,8 +29,11 @@ const createApiDecorator = ({value}, {api}, {input, meta}, {state}) => descripto
           }
         },
       }),
+      ...extras,
     ],
   };
+
+  return isFormApi ? value(finalDescriptor) : finalDescriptor;
 };
 
 export default createApiDecorator;

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -195,7 +195,7 @@ const createField = (
         },
       }),
 
-      // Basic elements
+      // Original elements
       ...filter(elements),
     ],
     finisher(target) {

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -14,6 +14,8 @@ const createField = (
 ) => descriptor => {
   assertKind('field', Kind.Class, descriptor);
 
+  const {elements, finisher = noop, kind} = descriptor;
+
   let constructor;
   const getConstructor = () => constructor;
 
@@ -40,13 +42,10 @@ const createField = (
   const $$update = Symbol();
   const $$updatingValid = Symbol();
 
-  const {elements, finisher: consumerFinisher, kind} = consumer(descriptor);
   const [supers, prepareSupers] = getSupers(elements, $.lifecycleKeys);
 
-  return {
+  return consumer({
     elements: [
-      ...filter(elements),
-
       // Public
       ...lifecycleMethod(
         {
@@ -188,17 +187,19 @@ const createField = (
         },
       }),
 
-      // Hooks
+      // Static Hooks
       $.hook({
         start() {
           subscribe.set(this, $$subscribe);
           update.set(this, $$update);
         },
       }),
+
+      // Basic elements
+      ...filter(elements),
     ],
     finisher(target) {
-      prepareSupers(target);
-
+      finisher(target);
       constructor = target;
 
       $api = api.get(target);
@@ -208,8 +209,6 @@ const createField = (
       assertRequiredProperty('field', 'api', 'form', $api);
       assertRequiredProperty('field', 'api', 'input', $input);
       assertRequiredProperty('field', 'api', 'meta', $meta);
-
-      consumerFinisher(target);
 
       $format = options.format.get(target);
       $formatOnBlur = options.formatOnBlur.get(target);
@@ -221,9 +220,10 @@ const createField = (
       $validateFields = options.validateFields.get(target);
 
       assertRequiredProperty('field', 'option', 'name', $name);
+      prepareSupers(target);
     },
     kind,
-  };
+  });
 };
 
 export default createField;

--- a/packages/form/src/form.js
+++ b/packages/form/src/form.js
@@ -99,7 +99,7 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
         },
       }),
 
-      // Basic elements
+      // Original elements
       ...filter(elements),
 
       // Own Hooks

--- a/packages/redux/__tests__/index.ts
+++ b/packages/redux/__tests__/index.ts
@@ -82,6 +82,29 @@ describe('@corpuscule/redux', () => {
       expect(reduxStore.getState).not.toHaveBeenCalled();
     });
 
+    it('receives store before user-defined connectedCallback is run', async () => {
+      const connectedCallbackSpy = jasmine.createSpy('connectedCallback');
+
+      @provider
+      class Provider extends CustomElement {
+        @api public store: Store = reduxStore;
+      }
+
+      @redux
+      class Connected extends CustomElement {
+        @unit((state: typeof reduxState) => state.test)
+        public test?: number;
+
+        public connectedCallback(): void {
+          connectedCallbackSpy(this.test);
+        }
+      }
+
+      await createSimpleContext(Provider, Connected);
+
+      expect(connectedCallbackSpy).toHaveBeenCalledWith(10);
+    });
+
     it('does not throw an error if class already have own lifecycle element', () => {
       expect(() => {
         @redux


### PR DESCRIPTION
The basic idea of this PR is about decorator execution order. The previous implementation had naive order where user-defined elements were run first, and only then decorator-specific elements were initialized. It led to a situation when you cannot expect that you can get context value during user-defined `connectedCallback`. 

This PR changes this situation allowing decorators to be wrappers. This allowance consists of following parts:
* Decorator elements go first, so they are executed before user-defined elements. Now you can expect context value accessible in user-defined `connectedCallback`.
* To be run in the correct order parent decorator should wrap children. It means that the parent's elements will be initialized before the child's. 

```javascript
const parent = ({elements, kind}) => ({
  elements: [
    ...parentDecoratorSpecificElements,
    ...elements, // here will be user-defined elements AND elements of children decorators
  ]
});

const child = ({elements, kind}) => parent({
  elements: [
     ...childSpecificDecoratorElements,
     ...elements, // here will be only user-defined elements
  ]
});
```