### PR TITLE
Simplify approach of sharing decorator properties

### DIFF
--- a/packages/form/src/api.js
+++ b/packages/form/src/api.js
@@ -3,16 +3,14 @@ import {hook} from '@corpuscule/utils/lib/descriptors';
 import {getName} from '@corpuscule/utils/lib/propertyUtils';
 import {apis} from './utils';
 
-const createApiDecorator = ({value}, {api}, {input, meta}, {state}) => descriptor => {
+const createApiDecorator = ({value}, shared) => descriptor => {
   assertKind('api', Kind.Field | Kind.Accessor, descriptor);
   assertPlacement('api', Placement.Own | Placement.Prototype, descriptor);
 
   const {extras = [], key} = descriptor;
   const name = getName(key);
 
-  const isFormApi = name === 'form';
-
-  if (!apis.includes(name) && !isFormApi) {
+  if (!apis.includes(name)) {
     throw new TypeError(`Property name ${name} is not allowed`);
   }
 
@@ -21,19 +19,14 @@ const createApiDecorator = ({value}, {api}, {input, meta}, {state}) => descripto
     extras: [
       hook({
         start() {
-          if (isFormApi) {
-            api.set(this, key);
-          } else {
-            const shared = name === 'input' ? input : name === 'meta' ? meta : state;
-            shared.set(this, key);
-          }
+          shared[name].set(this, key);
         },
       }),
       ...extras,
     ],
   };
 
-  return isFormApi ? value(finalDescriptor) : finalDescriptor;
+  return name === 'form' ? value(finalDescriptor) : finalDescriptor;
 };
 
 export default createApiDecorator;

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -9,8 +9,9 @@ const [connectedCallbackKey, disconnectedCallbackKey] = $.lifecycleKeys;
 
 const createField = (
   {consumer},
-  {api},
-  {input, meta, options, scheduler, subscribe, update},
+  {form: formApi, input, meta},
+  options,
+  {scheduler, subscribe, update},
 ) => descriptor => {
   assertKind('field', Kind.Class, descriptor);
 
@@ -19,7 +20,7 @@ const createField = (
   let constructor;
   const getConstructor = () => constructor;
 
-  let $api;
+  let $formApi;
   let $input;
   let $meta;
 
@@ -142,7 +143,7 @@ const createField = (
               this[$$update]();
             };
 
-            this[$$unsubscribe] = getValue(this, $api).registerField(
+            this[$$unsubscribe] = getValue(this, $formApi).registerField(
               getValue(this, $name),
               listener,
               ($subscription && getValue(this, $subscription)) || all,
@@ -202,11 +203,11 @@ const createField = (
       finisher(target);
       constructor = target;
 
-      $api = api.get(target);
+      $formApi = formApi.get(target);
       $input = input.get(target);
       $meta = meta.get(target);
 
-      assertRequiredProperty('field', 'api', 'form', $api);
+      assertRequiredProperty('field', 'api', 'form', $formApi);
       assertRequiredProperty('field', 'api', 'input', $input);
       assertRequiredProperty('field', 'api', 'meta', $meta);
 

--- a/packages/form/src/form.js
+++ b/packages/form/src/form.js
@@ -8,7 +8,7 @@ import {all, filter, noop} from './utils';
 
 const [connectedCallbackKey, disconnectedCallbackKey] = lifecycleKeys;
 
-const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => ({
+const createFormDecorator = ({provider}, {form: formApi, state}, {configInitializers}) => ({
   decorators,
   subscription = all,
 } = {}) => descriptor => {
@@ -16,7 +16,7 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
 
   const {elements, finisher = noop, kind} = descriptor;
 
-  let $api;
+  let $formApi;
   let constructor;
   let $state;
   let initializers;
@@ -35,7 +35,7 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
         {
           key: connectedCallbackKey,
           method() {
-            const instance = getValue(this, $api);
+            const instance = getValue(this, $formApi);
 
             if (decorators) {
               for (const decorate of decorators) {
@@ -88,7 +88,7 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
           e.preventDefault();
           e.stopPropagation();
 
-          getValue(this, $api).submit();
+          getValue(this, $formApi).submit();
         },
       }),
 
@@ -108,7 +108,7 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
         start() {
           setValue(
             this,
-            $api,
+            $formApi,
             createForm(
               initializers.reduce((acc, [key, initializer]) => {
                 acc[key] = initializer ? initializer.call(this) : undefined;
@@ -124,10 +124,10 @@ const createFormDecorator = ({provider}, {api}, {configInitializers, state}) => 
       finisher(target);
       constructor = target;
 
-      $api = api.get(target);
+      $formApi = formApi.get(target);
       $state = state.get(target);
 
-      assertRequiredProperty('form', 'api', 'form', $api);
+      assertRequiredProperty('form', 'api', 'form', $formApi);
       assertRequiredProperty('form', 'api', 'state', $state);
 
       initializers = configInitializers.get(target);

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -9,18 +9,20 @@ import {fieldOptions} from './utils';
 export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
   const context = createContext();
 
-  const commonShared = {
-    api: new WeakMap(),
-  };
-
-  const fieldShared = {
+  const apiShared = {
+    form: new WeakMap(),
     input: new WeakMap(),
     meta: new WeakMap(),
-    options: fieldOptions.reduce((map, option) => {
-      map[option] = new WeakMap();
+    state: new WeakMap(),
+  };
 
-      return map;
-    }, {}),
+  const optionShared = fieldOptions.reduce((map, option) => {
+    map[option] = new WeakMap();
+
+    return map;
+  }, {});
+
+  const fieldShared = {
     scheduler,
     subscribe: new WeakMap(),
     update: new WeakMap(),
@@ -29,13 +31,12 @@ export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
   const formShared = {
     compare: new WeakMap(),
     configInitializers: new WeakMap(),
-    state: new WeakMap(),
   };
 
-  const api = createApiDecorator(context, commonShared, fieldShared, formShared);
-  const field = createFieldDecorator(context, commonShared, fieldShared);
-  const form = createFormDecorator(context, commonShared, formShared);
-  const option = createOptionDecorator(commonShared, fieldShared, formShared);
+  const api = createApiDecorator(context, apiShared);
+  const field = createFieldDecorator(context, apiShared, optionShared, fieldShared);
+  const form = createFormDecorator(context, apiShared, formShared);
+  const option = createOptionDecorator(apiShared, optionShared, fieldShared, formShared);
 
   return {
     api,

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -22,21 +22,21 @@ export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
     return map;
   }, {});
 
-  const fieldShared = {
+  const propsShared = {
+    // @form properties
+    compare: new WeakMap(),
+    configInitializers: new WeakMap(),
+
+    // @field properties
     scheduler,
     subscribe: new WeakMap(),
     update: new WeakMap(),
   };
 
-  const formShared = {
-    compare: new WeakMap(),
-    configInitializers: new WeakMap(),
-  };
-
   const api = createApiDecorator(context, apiShared);
-  const field = createFieldDecorator(context, apiShared, optionShared, fieldShared);
-  const form = createFormDecorator(context, apiShared, formShared);
-  const option = createOptionDecorator(apiShared, optionShared, fieldShared, formShared);
+  const field = createFieldDecorator(context, apiShared, optionShared, propsShared);
+  const form = createFormDecorator(context, apiShared, propsShared);
+  const option = createOptionDecorator(apiShared, optionShared, propsShared);
 
   return {
     api,

--- a/packages/form/src/option.js
+++ b/packages/form/src/option.js
@@ -8,8 +8,7 @@ import {fieldOptions, formOptions} from './utils';
 const createOptionDecorator = (
   {form: formApi},
   options,
-  {subscribe, update},
-  {compare, configInitializers},
+  {compare, configInitializers, subscribe, update},
 ) => descriptor => {
   assertKind('option', Kind.Field | Kind.Method | Kind.Accessor, descriptor);
   assertPlacement('option', Placement.Own | Placement.Prototype, descriptor);

--- a/packages/form/src/option.js
+++ b/packages/form/src/option.js
@@ -6,8 +6,9 @@ import {noop} from '../../element/src/utils';
 import {fieldOptions, formOptions} from './utils';
 
 const createOptionDecorator = (
-  {api},
-  {options, subscribe, update},
+  {form: formApi},
+  options,
+  {subscribe, update},
   {compare, configInitializers},
 ) => descriptor => {
   assertKind('option', Kind.Field | Kind.Method | Kind.Accessor, descriptor);
@@ -112,7 +113,7 @@ const createOptionDecorator = (
     };
 
     let $compareInitialValues;
-    let $api;
+    let $formApi;
 
     const updateForm =
       name === 'initialValues'
@@ -123,12 +124,12 @@ const createOptionDecorator = (
                 shallowEqual
               ).call(this, getValue(this, key), initialValues)
             ) {
-              getValue(this, $api).initialize(initialValues);
+              getValue(this, $formApi).initialize(initialValues);
             }
           }
         : function(v) {
             if (this[key] !== v) {
-              getValue(this, $api).setConfig(name, v);
+              getValue(this, $formApi).setConfig(name, v);
             }
           };
 
@@ -144,7 +145,7 @@ const createOptionDecorator = (
       },
       finisher(target) {
         originalFinisher(target);
-        $api = api.get(target);
+        $formApi = formApi.get(target);
         $compareInitialValues = compare.get(target);
 
         configInitializers.get(target).push([

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -5,7 +5,7 @@ export const noop = () => {}; // eslint-disable-line no-empty-function
 
 export const formOptions = [...configOptions, 'compareInitialValues'];
 
-export const apis = ['input', 'meta', 'state'];
+export const apis = ['form', 'input', 'meta', 'state'];
 
 export const fieldOptions = [
   'format',

--- a/packages/redux/src/index.js
+++ b/packages/redux/src/index.js
@@ -6,21 +6,18 @@ import {createUnitDecorator} from './unit';
 export const createReduxContext = () => {
   const context = createContext();
 
-  const dispathcerShared = {
+  const shared = {
     store: new WeakMap(),
-  };
-
-  const unitShared = {
     units: new WeakMap(),
   };
 
   return {
     api: context.value,
-    dispatcher: createDispatcherDecorator(dispathcerShared),
+    dispatcher: createDispatcherDecorator(shared),
     isProvider: context.isProvider,
     provider: context.provider,
-    redux: createReduxDecorator(context, unitShared, dispathcerShared),
-    unit: createUnitDecorator(unitShared),
+    redux: createReduxDecorator(context, shared),
+    unit: createUnitDecorator(shared),
   };
 };
 

--- a/packages/redux/src/redux.js
+++ b/packages/redux/src/redux.js
@@ -9,7 +9,7 @@ const noop = () => {};
 
 const [, disconnectedCallbackKey] = lifecycleKeys;
 
-export const createReduxDecorator = ({consumer, value}, {units}, {store}) => descriptor => {
+export const createReduxDecorator = ({consumer, value}, {store, units}) => descriptor => {
   assertKind('connect', Kind.Class, descriptor);
 
   const {elements, finisher = noop, kind} = descriptor;


### PR DESCRIPTION
This PR improves and simplifies approach of sharing common properties between decorators (like `@api`, `@option`, etc.) in `@corpuscule/form` and `@corpuscule/redux`. 