### PR TITLE
Add Auto Fields

### DIFF
--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -21,6 +21,63 @@ or
 $ yarn add final-form @corpuscule/form
 ```
 
+## Concepts
+### Auto Field
+Auto fields are allowed not only to receive data comes up from native form elements with change 
+events but also to change these elements values by form updates. It happens automatically and does
+not require specific actions from the user.  
+
+To create an auto field add `{auto: true}` as a parameter for `@field` decorator creator. It will
+allow the field to receive changes from native form elements and update them on form change. Second
+parameter key, `selector`, can be used to make `querySelectorAll` request more specific. By default,
+it is `input, select, textarea`. You can make it wider by adding custom elements, like `input,
+select, textarea, my-element`, or make it more specific by removing or replacing native elements.
+
+Now, each change of native form element will change the corresponding form field, and each form
+update will change the value of native elements. The field also sets `name` properties of all
+selected elements to its name, so it is useless to set names manually.
+```html
+<script>
+  @field({auto: true, selector: 'input'})
+  class Field extends HTMLElement {
+    @api formApi;
+    @api input;
+    @api meta;
+
+    @option name;
+  }
+  
+  customElements.define('x-field', Field);
+</script>
+<x-form>
+  <x-field name="foo-bar">
+    <input type="radio" value="foo">
+    <input type="radio" value="bar">
+  </x-field>
+</x-form>
+```
+#### Customized Built-In Element
+You can also do the same with customized built-in elements. The only difference is that CB elements
+will change themselves instead of searching native elements.
+```html
+<script>
+  @field({auto: true})
+  class Field extends HTMLSelectElement {
+    @api formApi;
+    @api input;
+    @api meta;
+
+    @option name = 'foo-bar';
+  }
+  
+  customElements.define('x-field', Field, {extends: 'input'});
+</script>
+<x-form>
+  <input is="x-field" type="radio" value="foo">
+  <input is="x-field" type="radio" value="bar">
+</x-form>
+```
+
 ## API
 ### Common
 #### `@api: PropertyDecorator`
@@ -47,10 +104,10 @@ decorator.
 
 ### Form
 #### `@form(params?: FormDecoratorParams): ClassDecorator`
-Form decorator makes element a 🏁 FinalForm provider via [`@corpsucule/context`](../context) with
-form instance as a context value. 
+Form decorator makes the element a 🏁 FinalForm provider via [`@corpsucule/context`](../context)
+with form instance as a context value. 
 
-Decorator can receive `FormDecoratorParams` object which contains:
+The decorator can receive `FormDecoratorParams` object which contains:
 * `decorators?: Decorator[]` - a list of [🏁 FinalForm decorators](https://github.com/final-form/final-form#decorator-form-formapi--unsubscribe)
 to apply to the form.
 * `subscription?: FormSubscription` - a [`FormSubscription`](https://github.com/final-form/final-form#formsubscription--string-boolean-)
@@ -86,9 +143,14 @@ section.
 This function is used to compare new initial values that are received by `initialValues` form
 option. By default simple checking of shallow equality is performed.
 
-#### `@field: ClassDecorator`
-Field decorator makes element a 🏁 FinalForm field, a consumer via [`@corpsucule/context`](../context)
+#### `@field(params?: FieldDecoratorParams): ClassDecorator`
+Field decorator makes the element a 🏁 FinalForm field, a consumer via [`@corpsucule/context`](../context)
 with form instance as a context value.
+
+The decorator can receive `FieldDecoratorParams` object which contains:
+* `auto?: boolean` - a property that creates [Auto Field](#autofield) from a simple `Field`.
+* `selector?: string` - Auto Field uses this selector to search native form elements in the light
+DOM. More details [here](#autofield).  
 
 #### Field `@api` decorator
 Field `@api` decorator has following property names it can be applied to:

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -558,7 +558,7 @@ const testField = () => {
             @api public readonly input!: FieldInputProps<object>;
             @api public readonly meta!: FieldMetaProps;
           }
-        }).toThrowError('@field() requires name property marked with @option');
+        }).toThrowError('@field requires name property marked with @option');
       });
     });
 
@@ -568,7 +568,7 @@ const testField = () => {
           @field()
           // @ts-ignore
           class Field extends CustomElement {}
-        }).toThrowError('@field() requires form property marked with @api');
+        }).toThrowError('@field requires form property marked with @api');
 
         expect(() => {
           @field()
@@ -576,7 +576,7 @@ const testField = () => {
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
           }
-        }).toThrowError('@field() requires input property marked with @api');
+        }).toThrowError('@field requires input property marked with @api');
 
         expect(() => {
           @field()
@@ -585,7 +585,7 @@ const testField = () => {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
           }
-        }).toThrowError('@field() requires meta property marked with @api');
+        }).toThrowError('@field requires meta property marked with @api');
       });
 
       it('allows using accessors for all api elements', async () => {

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -614,6 +614,37 @@ const testField = () => {
           }
         }).toThrowError('@field requires name property marked with @option');
       });
+
+      it('does not run registerField on connection if name has no value', async () => {
+        @form()
+        class Form extends CustomElement {
+          @api public readonly formApi!: FormApi;
+          @api public readonly state!: FormState;
+
+          @option
+          public onSubmit(): void {}
+        }
+
+        @field()
+        class Field extends CustomElement {
+          @api public readonly formApi!: FormApi;
+          @api public readonly input!: FieldInputProps<string>;
+          @api public readonly meta!: FieldMetaProps;
+
+          @option public readonly name?: string;
+        }
+
+        const formTag = defineCE(Form);
+        const fieldTag = defineCE(Field);
+
+        await fixture(`
+        <${formTag}>
+          <${fieldTag}></${fieldTag}>
+        </${formTag}>
+      `);
+
+        expect(formSpyObject.registerField).not.toHaveBeenCalled();
+      });
     });
 
     describe('@api', () => {

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -3,7 +3,13 @@ import {defineCE, fixture} from '@open-wc/testing-helpers';
 import {FieldState, FieldValidator, FormApi, FormState} from 'final-form';
 import {formSpyObject, unsubscribe} from '../../../test/mocks/finalForm';
 import {createSimpleContext, CustomElement} from '../../../test/utils';
-import {createFormContext, FieldInputProps, FieldMetaProps, FormDecorator} from '../src';
+import {
+  createFormContext,
+  FieldDecorator,
+  FieldInputProps,
+  FieldMetaProps,
+  FormDecorator,
+} from '../src';
 import {all} from '../src/utils';
 
 const testField = () => {
@@ -15,7 +21,7 @@ const testField = () => {
 
     let api: PropertyDecorator;
     let form: FormDecorator;
-    let field: ClassDecorator;
+    let field: FieldDecorator;
     let option: PropertyDecorator;
 
     const subscribeField = <T>(fieldElement: T): [(state: FieldState) => void, FieldValidator] => {
@@ -79,7 +85,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<string>;
@@ -107,7 +113,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<string>;
@@ -135,7 +141,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<string>;
@@ -181,7 +187,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<object>;
@@ -213,7 +219,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<object>;
@@ -250,7 +256,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<object>;
@@ -280,7 +286,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<object>;
@@ -306,7 +312,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<object>;
@@ -333,7 +339,7 @@ const testField = () => {
         public onSubmit(): void {}
       }
 
-      @field
+      @field()
       class Field extends CustomElement {
         @api public readonly formApi!: FormApi;
         @api public readonly input!: FieldInputProps<object>;
@@ -360,7 +366,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           @api public readonly formApi!: FormApi;
           @api public readonly input!: FieldInputProps<object>;
@@ -388,7 +394,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           @api public readonly formApi!: FormApi;
           @api public readonly input!: FieldInputProps<object>;
@@ -415,7 +421,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           @api public readonly formApi!: FormApi;
           @api public readonly input!: FieldInputProps<object>;
@@ -443,7 +449,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           @api public readonly formApi!: FormApi;
           @api public readonly input!: FieldInputProps<object>;
@@ -471,7 +477,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           @api public readonly formApi!: FormApi;
           @api public readonly input!: FieldInputProps<object>;
@@ -503,7 +509,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           @api public readonly formApi!: FormApi;
           @api public readonly input!: FieldInputProps<object>;
@@ -527,7 +533,7 @@ const testField = () => {
 
       it('throws an error if option name is not one of Field config keys', () => {
         expect(() => {
-          @field
+          @field()
           // @ts-ignore
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
@@ -546,41 +552,41 @@ const testField = () => {
 
       it('requires name field defined', () => {
         expect(() => {
-          @field
+          @field()
           // @ts-ignore
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
             @api public readonly meta!: FieldMetaProps;
           }
-        }).toThrowError('@field requires name property marked with @option');
+        }).toThrowError('@field() requires name property marked with @option');
       });
     });
 
     describe('@api', () => {
       it('requires form, input and meta fields defined', () => {
         expect(() => {
-          @field
+          @field()
           // @ts-ignore
           class Field extends CustomElement {}
-        }).toThrowError('@field requires form property marked with @api');
+        }).toThrowError('@field() requires form property marked with @api');
 
         expect(() => {
-          @field
+          @field()
           // @ts-ignore
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
           }
-        }).toThrowError('@field requires input property marked with @api');
+        }).toThrowError('@field() requires input property marked with @api');
 
         expect(() => {
-          @field
+          @field()
           // @ts-ignore
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
           }
-        }).toThrowError('@field requires meta property marked with @api');
+        }).toThrowError('@field() requires meta property marked with @api');
       });
 
       it('allows using accessors for all api elements', async () => {
@@ -593,7 +599,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           public storage!: FormApi;
 
@@ -632,7 +638,7 @@ const testField = () => {
         }).toThrow(new TypeError('Property name notForm is not allowed'));
 
         expect(() => {
-          @field
+          @field()
           // @ts-ignore
           class Field extends CustomElement {
             @api public readonly notInput!: FieldInputProps<object>;
@@ -654,7 +660,7 @@ const testField = () => {
             public onSubmit(): void {}
           }
 
-          @field
+          @field()
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
@@ -682,7 +688,7 @@ const testField = () => {
             public onSubmit(): void {}
           }
 
-          @field
+          @field()
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
@@ -722,7 +728,7 @@ const testField = () => {
             public onSubmit(): void {}
           }
 
-          @field
+          @field()
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
@@ -752,7 +758,7 @@ const testField = () => {
             public onSubmit(): void {}
           }
 
-          @field
+          @field()
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
@@ -790,7 +796,7 @@ const testField = () => {
             public onSubmit(): void {}
           }
 
-          @field
+          @field()
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly input!: FieldInputProps<object>;
@@ -824,7 +830,7 @@ const testField = () => {
           public onSubmit(): void {}
         }
 
-        @field
+        @field()
         class Field extends CustomElement {
           @api public readonly formApi!: FormApi;
           @api public readonly input!: FieldInputProps<object>;
@@ -1003,7 +1009,7 @@ const testField = () => {
 
       it('does not throw an error if class already have own lifecycle element', () => {
         expect(() => {
-          @field
+          @field()
           // @ts-ignore
           class Field extends CustomElement {
             @api public readonly formApi!: FormApi;

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -1195,6 +1195,23 @@ const testField = () => {
           callListener(listener, {...state, value: false});
           expect(fieldElement.checked).not.toBeTruthy();
         });
+
+        it('sets field name to all inner elements (if container)', async () => {
+          const formElement = await fixture(`
+            <${formTag}>
+              <${fieldTag}>
+                <input type="checkbox" value="foo"/>         
+                <input type="checkbox" value="bar"/>
+              </${fieldTag}>
+            </${formTag}>
+          `);
+
+          const inputElementFoo = formElement.querySelector<HTMLInputElement>('input[value=foo]')!;
+          const inputElementBar = formElement.querySelector<HTMLInputElement>('input[value=bar]')!;
+
+          expect(inputElementFoo.name).toBe('test');
+          expect(inputElementBar.name).toBe('test');
+        });
       });
 
       describe('radio', () => {

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -378,6 +378,44 @@ const testField = () => {
       expect(unsubscribe).toHaveBeenCalled();
     });
 
+    it('does not change form value if event is not custom and field is not auto', async () => {
+      @form()
+      class Form extends CustomElement {
+        @api public readonly formApi!: FormApi;
+        @api public readonly state!: FormState;
+
+        @option
+        public onSubmit(): void {}
+      }
+
+      @field()
+      class Field extends CustomElement {
+        @api public readonly formApi!: FormApi;
+        @api public readonly input!: FieldInputProps<string>;
+        @api public readonly meta!: FieldMetaProps;
+
+        @option public readonly name: string = 'test';
+      }
+
+      const formTag = defineCE(Form);
+      const fieldTag = defineCE(Field);
+
+      const formElement = await fixture(`
+        <${formTag}>
+          <${fieldTag}>
+            <input type="text">
+          </${fieldTag}>
+        </${formTag}>
+      `);
+
+      const inputElement = formElement.querySelector<HTMLInputElement>('input')!;
+
+      inputElement.value = 'test';
+      inputElement.dispatchEvent(new Event('change', {bubbles: true}));
+
+      expect(state.change).not.toHaveBeenCalled();
+    });
+
     describe('@option', () => {
       it('resubscribes on name value change', async () => {
         @form()

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -33,16 +33,17 @@ const testField = () => {
       return [listener, getValidator()];
     };
 
-    const updateField = <T>(fieldElement: T, listener: (state: FieldState) => void) => {
-      listener(state);
-
+    const updateField = <T>(fieldElement: T) => {
       const [update] = scheduler.calls.mostRecent().args;
       update.call(fieldElement);
     };
 
-    const subscribeAndUpdateField = <T>(fieldElement: T): void => {
+    const subscribeAndUpdateField = <T>(fieldElement: T): ((state: FieldState) => void) => {
       const [listener] = subscribeField(fieldElement);
-      updateField(fieldElement, listener);
+      listener(state);
+      updateField(fieldElement);
+
+      return listener;
     };
 
     beforeEach(() => {
@@ -197,8 +198,7 @@ const testField = () => {
       }
 
       const [, fieldElement] = await createSimpleContext(Form, Field);
-      const [listener] = subscribeField(fieldElement);
-      updateField(fieldElement, listener);
+      subscribeAndUpdateField(fieldElement);
 
       expect(scheduler).toHaveBeenCalledTimes(2);
       expect(fieldElement.input).toEqual({
@@ -240,8 +240,7 @@ const testField = () => {
 
       spyOn(fieldElement, 'format').and.callThrough();
 
-      const [listener] = subscribeField(fieldElement);
-      updateField(fieldElement, listener);
+      subscribeAndUpdateField(fieldElement);
 
       expect(fieldElement.format).toHaveBeenCalledWith(fieldValue, 'test');
     });
@@ -619,8 +618,7 @@ const testField = () => {
         }
 
         const [, fieldElement] = await createSimpleContext(Form, Field);
-        const [listener] = subscribeField(fieldElement);
-        updateField(fieldElement, listener);
+        subscribeAndUpdateField(fieldElement);
 
         expect(fieldElement.storage).toBe(formSpyObject);
       });
@@ -670,8 +668,7 @@ const testField = () => {
           }
 
           const [, fieldElement] = await createSimpleContext(Form, Field);
-          const [listener] = subscribeField(fieldElement);
-          updateField(fieldElement, listener);
+          subscribeAndUpdateField(fieldElement);
 
           fieldElement.dispatchEvent(new Event('blur'));
 
@@ -708,9 +705,7 @@ const testField = () => {
           const [, fieldElement] = await createSimpleContext(Form, Field);
 
           spyOn(fieldElement, 'format').and.callThrough();
-
-          const [listener] = subscribeField(fieldElement);
-          updateField(fieldElement, listener);
+          subscribeAndUpdateField(fieldElement);
 
           fieldElement.dispatchEvent(new Event('blur'));
 
@@ -738,8 +733,7 @@ const testField = () => {
           }
 
           const [, fieldElement] = await createSimpleContext(Form, Field);
-          const [listener] = subscribeField(fieldElement);
-          updateField(fieldElement, listener);
+          subscribeAndUpdateField(fieldElement);
 
           const newFieldValue: object = {};
 
@@ -773,8 +767,7 @@ const testField = () => {
           }
 
           const [, fieldElement] = await createSimpleContext(Form, Field);
-          const [listener] = subscribeField(fieldElement);
-          updateField(fieldElement, listener);
+          subscribeAndUpdateField(fieldElement);
 
           spyOn(fieldElement, 'parse').and.callThrough();
 
@@ -806,8 +799,7 @@ const testField = () => {
           }
 
           const [, fieldElement] = await createSimpleContext(Form, Field);
-          const [listener] = subscribeField(fieldElement);
-          updateField(fieldElement, listener);
+          subscribeAndUpdateField(fieldElement);
 
           fieldElement.dispatchEvent(new Event('focus'));
 

--- a/packages/form/src/api.js
+++ b/packages/form/src/api.js
@@ -14,7 +14,7 @@ const createApiDecorator = ({value}, shared, {ref}) => descriptor => {
     throw new TypeError(`Property name ${name} is not allowed`);
   }
 
-  if (name === 'ref') {
+  if (name === 'refs') {
     let $$ref;
 
     return accessor({

--- a/packages/form/src/api.js
+++ b/packages/form/src/api.js
@@ -1,9 +1,9 @@
 import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/lib/asserts';
-import {hook} from '@corpuscule/utils/lib/descriptors';
+import {accessor, hook} from '@corpuscule/utils/lib/descriptors';
 import {getName} from '@corpuscule/utils/lib/propertyUtils';
 import {apis} from './utils';
 
-const createApiDecorator = ({value}, shared) => descriptor => {
+const createApiDecorator = ({value}, shared, {ref}) => descriptor => {
   assertKind('api', Kind.Field | Kind.Accessor, descriptor);
   assertPlacement('api', Placement.Own | Placement.Prototype, descriptor);
 
@@ -12,6 +12,20 @@ const createApiDecorator = ({value}, shared) => descriptor => {
 
   if (!apis.includes(name)) {
     throw new TypeError(`Property name ${name} is not allowed`);
+  }
+
+  if (name === 'ref') {
+    let $$ref;
+
+    return accessor({
+      finisher(target) {
+        $$ref = ref.get(target);
+      },
+      get() {
+        return this[$$ref];
+      },
+      key,
+    });
   }
 
   const finalDescriptor = {

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -68,7 +68,10 @@ const createField = (
             }
 
             supers[connectedCallbackKey].call(this);
-            this[$$subscribe]();
+
+            if (getValue(this, $name)) {
+              this[$$subscribe]();
+            }
           },
         },
         supers,

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -132,19 +132,18 @@ const createField = (
         bound: true,
         key: $$onChange,
         method(event) {
+          const isCustomEvent = event instanceof CustomEvent;
           const parse = $parse && getValue(this, $parse);
           const {change, name, value} = this[$$state];
 
-          let changeValue;
+          // We should update form only if it is an auto field or event is custom.
+          // By default field does not receive native change events.
+          if (isCustomEvent || auto) {
+            const changed = isCustomEvent ? event.detail : getTargetValue(event.target, value);
+            change(parse ? parse(changed, name) : changed);
 
-          if (event instanceof CustomEvent) {
-            changeValue = event.detail;
-          } else if (auto) {
-            changeValue = getTargetValue(event.target, value);
-            this[$$selfChange] = true;
+            this[$$selfChange] = !isCustomEvent;
           }
-
-          change(parse ? parse(changeValue, name) : changeValue);
         },
       }),
       $.method({

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -20,6 +20,7 @@ const createField = (
   let constructor;
   const getConstructor = () => constructor;
 
+  let isNativeField;
   let getRef = noop;
 
   let $formApi;
@@ -59,6 +60,12 @@ const createField = (
             this.addEventListener('blur', this[$$onBlur]);
             this.addEventListener('change', this[$$onChange]);
             this.addEventListener('focus', this[$$onFocus]);
+
+            if (auto && !isNativeField) {
+              for (const element of this[$$ref]) {
+                element.name = getValue(this, $name);
+              }
+            }
 
             supers[connectedCallbackKey].call(this);
             this[$$subscribe]();
@@ -232,18 +239,17 @@ const createField = (
     finisher(target) {
       finisher(target);
       constructor = target;
+      isNativeField =
+        target.prototype instanceof HTMLInputElement ||
+        target.prototype instanceof HTMLSelectElement ||
+        target.prototype instanceof HTMLTextAreaElement;
 
       $formApi = formApi.get(target);
       $input = input.get(target);
       $meta = meta.get(target);
 
       if (auto) {
-        getRef =
-          target.prototype instanceof HTMLInputElement ||
-          target.prototype instanceof HTMLSelectElement ||
-          target.prototype instanceof HTMLTextAreaElement
-            ? self => self
-            : self => self.querySelectorAll(selector);
+        getRef = isNativeField ? self => self : self => self.querySelectorAll(selector);
       }
 
       assertRequiredProperty('field', 'api', 'form', $formApi);

--- a/packages/form/src/index.d.ts
+++ b/packages/form/src/index.d.ts
@@ -9,7 +9,13 @@ export interface FormDecoratorParams {
   readonly subscription?: FormSubscription;
 }
 
+export interface FieldDecoratorParams {
+  readonly auto?: boolean;
+  readonly selector?: string;
+}
+
 export type FormDecorator = (params?: FormDecoratorParams) => ClassDecorator;
+export type FieldDecorator = (params?: FieldDecoratorParams) => ClassDecorator;
 
 export interface FieldInputProps<T> {
   readonly name: string;
@@ -27,14 +33,14 @@ export interface FormContextOptions {
 
 export const api: PropertyDecorator;
 export const form: FormDecorator;
-export const field: ClassDecorator;
+export const field: FieldDecorator;
 export const isForm: ReturnType<typeof createContext>['isProvider'];
 export const option: PropertyDecorator;
 
 export interface FormContext {
   readonly api: PropertyDecorator;
   readonly form: FormDecorator;
-  readonly field: ClassDecorator;
+  readonly field: FieldDecorator;
   readonly isForm: ReturnType<typeof createContext>['isProvider'];
   readonly option: PropertyDecorator;
 }

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -28,12 +28,13 @@ export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
     configInitializers: new WeakMap(),
 
     // @field properties
+    ref: new WeakMap(),
     scheduler,
     subscribe: new WeakMap(),
     update: new WeakMap(),
   };
 
-  const api = createApiDecorator(context, apiShared);
+  const api = createApiDecorator(context, apiShared, propsShared);
   const field = createFieldDecorator(context, apiShared, optionShared, propsShared);
   const form = createFormDecorator(context, apiShared, propsShared);
   const option = createOptionDecorator(apiShared, optionShared, propsShared);

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -5,7 +5,7 @@ export const noop = () => {}; // eslint-disable-line no-empty-function
 
 export const formOptions = [...configOptions, 'compareInitialValues'];
 
-export const apis = ['formApi', 'input', 'meta', 'state'];
+export const apis = ['formApi', 'input', 'meta', 'refs', 'state'];
 
 export const fieldOptions = [
   'format',

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -58,6 +58,36 @@ export const getTargetValue = (
   }
 };
 
+export const setTargetValues = (targets, formValue) => {
+  const isFormValueArray = Array.isArray(formValue);
+
+  for (const target of targets) {
+    switch (target.type) {
+      case 'checkbox':
+        if (target.value === undefined) {
+          target.checked = !!formValue;
+        } else {
+          target.checked = isFormValueArray && formValue.includes(target.value);
+        }
+        break;
+      case 'radio':
+        target.checked = formValue === target.value;
+        break;
+      case 'select':
+        target.value = formValue;
+        break;
+      case 'select-multiple':
+        for (let i = 0; i < target.options; i++) {
+          target.options[i].selected =
+            isFormValueArray && formValue.includes(target.options[i].value);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+};
+
 export const filter = elements =>
   elements.filter(
     ({key, placement}) => !(lifecycleKeys.includes(key) && placement === 'prototype'),

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -64,11 +64,7 @@ export const setTargetValues = (targets, formValue) => {
   for (const target of targets) {
     switch (target.type) {
       case 'checkbox':
-        if (target.value === undefined) {
-          target.checked = !!formValue;
-        } else {
-          target.checked = isFormValueArray && formValue.includes(target.value);
-        }
+        target.checked = isFormValueArray ? formValue.includes(target.value) : !!formValue;
         break;
       case 'radio':
         target.checked = formValue === target.value;
@@ -79,7 +75,6 @@ export const setTargetValues = (targets, formValue) => {
             isFormValueArray && formValue.includes(target.options[i].value);
         }
         break;
-      case 'select':
       default:
         target.value = formValue;
     }

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -73,17 +73,15 @@ export const setTargetValues = (targets, formValue) => {
       case 'radio':
         target.checked = formValue === target.value;
         break;
-      case 'select':
-        target.value = formValue;
-        break;
       case 'select-multiple':
         for (let i = 0; i < target.options; i++) {
           target.options[i].selected =
             isFormValueArray && formValue.includes(target.options[i].value);
         }
         break;
+      case 'select':
       default:
-        break;
+        target.value = formValue;
     }
   }
 };

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -29,17 +29,19 @@ export const getTargetValue = (
   {checked, defaultValue, selectedOptions, type, value},
   formValue,
 ) => {
+  const isFormValueArray = Array.isArray(formValue);
+
   switch (type) {
     case 'checkbox': {
       // Form maintains an array, not just a boolean
       if (defaultValue) {
         // Add value to formValue array
         if (checked) {
-          return Array.isArray(formValue) ? formValue.concat(value) : [value];
+          return isFormValueArray ? [...formValue, value] : [value];
         }
 
         // Remove value from formValue array
-        if (!Array.isArray(formValue)) {
+        if (!isFormValueArray) {
           return formValue;
         }
 
@@ -54,30 +56,36 @@ export const getTargetValue = (
     case 'select-multiple':
       return Array.from(selectedOptions, option => option.value);
     default:
+      // Element input[type=radio] is also here
       return value;
   }
 };
 
-export const setTargetValues = (targets, formValue) => {
-  const isFormValueArray = Array.isArray(formValue);
+const setSingleValue = (target, formValue) => {
+  switch (target.type) {
+    case 'checkbox':
+      target.checked = Array.isArray(formValue) ? formValue.includes(target.value) : !!formValue;
+      break;
+    case 'radio':
+      target.checked = formValue === target.value;
+      break;
+    case 'select-multiple':
+      for (const option of target.options) {
+        option.selected = Array.isArray(formValue) && formValue.includes(option.value);
+      }
+      break;
+    default:
+      target.value = formValue;
+  }
+};
 
-  for (const target of targets) {
-    switch (target.type) {
-      case 'checkbox':
-        target.checked = isFormValueArray ? formValue.includes(target.value) : !!formValue;
-        break;
-      case 'radio':
-        target.checked = formValue === target.value;
-        break;
-      case 'select-multiple':
-        for (let i = 0; i < target.options; i++) {
-          target.options[i].selected =
-            isFormValueArray && formValue.includes(target.options[i].value);
-        }
-        break;
-      default:
-        target.value = formValue;
+export const setTargetValues = (targets, formValue) => {
+  if (targets instanceof NodeList) {
+    for (const target of targets) {
+      setSingleValue(target, formValue);
     }
+  } else {
+    setSingleValue(targets, formValue);
   }
 };
 

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
     "no-unused-variable": false,
     "no-unnecessary-class": false,
     "prettier": [true, ".prettierrc"],
+    "naming-convention": false,
     "ter-padded-blocks": false
   }
 }


### PR DESCRIPTION
This PR introduces a significant fix for the `@corpuscule/form` package. It allows not only receiving values from the native form elements but also to set form values to them. Before, users were forced to solve this problem by themselves.

## Auto fields
This PR introduces a new concept: auto fields. In other words, they are fields that are allowed not only to receive data that comes up with change events but also to send data downward, to native form elements. The changes in the current code are the following:
```html
<script>
  @field({auto: true})
  class Field extends HTMLElement {
    @api public readonly formApi;
    @api public readonly input;
    @api public readonly meta;

    @option public readonly name: string = 'test';
  }

  customElement.define('x-field', Field);
</script>
<x-form>
  <x-field>
    <input type="text" value="Hello World!">
  </x-field>
</x-form>
```
Now all you write in the `<input>` will be recorded in the form and all form changes will be written to the `<input>`. 

### Multiple elements in the container
You can put several items into the container. E.g., if you need a set of `radio` buttons, you can put all of them to the `<x-field>`. It will take care of all of them. 
```html
<x-form>
  <x-field>
    <input type="radio" value="foo">
    <input type="radio" value="bar">
  </x-field>
</x-form>
```

### Customized Built-in Elements
You can do the same with Customized Built-in Element. All you need is to extend `HTMLInputElement` (or `HTMLSelectElement` or `HTMLTextAreaElement`) and to put it to under the form:
```html
<x-form>
  <input is="x-field" type="text" value="Hello World!">
</x-form>
```

## Breaking changes
`@field` is now a function that returns decorator, not the decorator itself.