### PR TITLE
Convert undefined and null values to empty string for native form elements

### DIFF
--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -1091,6 +1091,29 @@ const testField = () => {
 
           expect(fieldElement.value).toBe('a2');
         });
+
+        it('will convert undefined and null into an empty string on form update', async () => {
+          state.value = 'a1';
+
+          const formElement = await fixture(`
+            <${formTag}>
+              <${fieldTag}>
+                <input type="text" value="a1"/>         
+              </${fieldTag}>
+            </${formTag}>
+          `);
+
+          const inputElement = formElement.querySelector<HTMLInputElement>('input')!;
+          const [listener] = subscriptionInfo.listeners;
+
+          callListener(listener, {...state, value: undefined});
+
+          expect(inputElement.value).toBe('');
+
+          callListener(listener, {...state, value: null});
+
+          expect(inputElement.value).toBe('');
+        });
       });
 
       describe('checkbox', () => {

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -2,7 +2,7 @@ import {assertKind, assertRequiredProperty, Kind} from '@corpuscule/utils/lib/as
 import * as $ from '@corpuscule/utils/lib/descriptors';
 import {method as lifecycleMethod} from '@corpuscule/utils/lib/lifecycleDescriptors';
 import {getValue, setValue} from '@corpuscule/utils/lib/propertyUtils';
-import {all, filter, getTargetValue, noop, setTargetValues} from './utils';
+import {all, filter, getTargetValue, isNativeElement, noop, setTargetValues} from './utils';
 import getSupers from '@corpuscule/utils/lib/getSupers';
 
 const [connectedCallbackKey, disconnectedCallbackKey] = $.lifecycleKeys;
@@ -241,10 +241,7 @@ const createField = (
     finisher(target) {
       finisher(target);
       constructor = target;
-      isNativeField =
-        target.prototype instanceof HTMLInputElement ||
-        target.prototype instanceof HTMLSelectElement ||
-        target.prototype instanceof HTMLTextAreaElement;
+      isNativeField = isNativeElement(target.prototype);
 
       $formApi = formApi.get(target);
       $input = input.get(target);

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -25,6 +25,11 @@ export const all = formSubscriptionItems.reduce((result, key) => {
   return result;
 }, {});
 
+export const isNativeElement = element =>
+  element instanceof HTMLInputElement ||
+  element instanceof HTMLSelectElement ||
+  element instanceof HTMLTextAreaElement;
+
 export const getTargetValue = (
   {checked, defaultValue, selectedOptions, type, value},
   formValue,
@@ -75,7 +80,8 @@ const setSingleValue = (target, formValue) => {
       }
       break;
     default:
-      target.value = formValue;
+      target.value =
+        isNativeElement && (formValue === null || formValue === undefined) ? '' : formValue;
   }
 };
 


### PR DESCRIPTION
This PR fixes `undefined` and `null` values in text fields appearing if these fields in the form don't have an initial value. 