### PR TITLE
Simplify 🏁 Final Form instance setting up

### DIFF
--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -25,7 +25,7 @@ export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
   const propsShared = {
     // @form properties
     compare: new WeakMap(),
-    configInitializers: new WeakMap(),
+    configOptions: new WeakMap(),
 
     // @field properties
     ref: new WeakMap(),

--- a/packages/form/src/option.js
+++ b/packages/form/src/option.js
@@ -8,7 +8,7 @@ import {fieldOptions, formOptions} from './utils';
 const createOptionDecorator = (
   {formApi},
   options,
-  {compare, configInitializers, subscribe, update},
+  {compare, configOptions, subscribe, update},
 ) => descriptor => {
   assertKind('option', Kind.Field | Kind.Method | Kind.Accessor, descriptor);
   assertPlacement('option', Placement.Own | Placement.Prototype, descriptor);
@@ -102,12 +102,7 @@ const createOptionDecorator = (
     methodPart = {
       finisher(target) {
         originalFinisher(target);
-        configInitializers.get(target).push([
-          key,
-          function() {
-            return value.bind(this);
-          },
-        ]);
+        configOptions.get(target).push(key);
       },
     };
 
@@ -146,15 +141,7 @@ const createOptionDecorator = (
         originalFinisher(target);
         $formApi = formApi.get(target);
         $compareInitialValues = compare.get(target);
-
-        configInitializers.get(target).push([
-          key,
-          get
-            ? function() {
-                return get.call(this);
-              }
-            : initializer,
-        ]);
+        configOptions.get(target).push(key);
       },
     };
   }


### PR DESCRIPTION
This PR simplifies the mechanics of setting up 🏁 Final Form instance, particularly reduces the number of option initializers calls. 