### PR TITLE
Form: allow to use same names for both form and field options

### DIFF
--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -645,6 +645,44 @@ const testField = () => {
 
         expect(formSpyObject.registerField).not.toHaveBeenCalled();
       });
+
+      it('properly sets validate option', async () => {
+        @form()
+        class Form extends CustomElement {
+          @api public readonly formApi!: FormApi;
+          @api public readonly state!: FormState;
+
+          @option
+          public onSubmit(): void {}
+        }
+
+        @field()
+        class Field extends CustomElement {
+          @api public readonly formApi!: FormApi;
+          @api public readonly input!: FieldInputProps<string>;
+          @api public readonly meta!: FieldMetaProps;
+
+          @option public readonly name: string = 'test';
+
+          @option
+          public validate(): void {}
+        }
+
+        const formTag = defineCE(Form);
+        const fieldTag = defineCE(Field);
+
+        const formElement = await fixture(`
+          <${formTag}>
+            <${fieldTag}></${fieldTag}>
+          </${formTag}>
+        `);
+
+        const fieldElement = formElement.querySelector<Field>(fieldTag)!;
+
+        const [, , , {getValidator}] = formSpyObject.registerField.calls.mostRecent().args;
+
+        expect(getValidator()).toBe(fieldElement.validate);
+      });
     });
 
     describe('@api', () => {
@@ -931,10 +969,10 @@ const testField = () => {
         customElements.define(nativeFieldTag, Field, {extends: 'input'});
 
         const formElement = await fixture(`
-            <${formTag}>
-              <input is="${nativeFieldTag}" type="text">
-            </${formTag}>
-          `);
+          <${formTag}>
+            <input is="${nativeFieldTag}" type="text">
+          </${formTag}>
+        `);
 
         const fieldElement = formElement.querySelector<Field>('input')!;
 

--- a/packages/form/__tests__/form.ts
+++ b/packages/form/__tests__/form.ts
@@ -410,11 +410,32 @@ const testForm = () => {
         expect(() => {
           @form()
           // @ts-ignore
-          class FormField extends CustomElement {
+          class Test extends CustomElement {
             @api public readonly formApi!: FormApi;
             @api public readonly state!: FormState;
           }
         }).toThrowError('@form requires onSubmit property marked with @option');
+      });
+
+      it('properly sets validate option', async () => {
+        @form()
+        class Test extends CustomElement {
+          @api public readonly formApi!: FormApi;
+          @api public readonly state!: FormState;
+
+          @option
+          public onSubmit(): void {}
+
+          @option
+          public validate(): void {}
+        }
+
+        const tag = defineCE(Test);
+        const test = (await fixture(`<${tag}></${tag}>`)) as Test;
+
+        const [{validate}] = createForm.calls.mostRecent().args;
+
+        expect(validate).toBe(test.validate);
       });
     });
 

--- a/packages/form/src/form.js
+++ b/packages/form/src/form.js
@@ -130,8 +130,7 @@ const createFormDecorator = ({provider}, {formApi, state}, {configOptions}) => (
             $formApi,
             createForm(
               configs.reduce((acc, key) => {
-                const configValue = this[key];
-                acc[key] = typeof configValue === 'function' ? configValue.bind(this) : configValue;
+                acc[key] = this[key];
 
                 return acc;
               }, {}),

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -37,7 +37,7 @@ export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
   const api = createApiDecorator(context, apiShared, propsShared);
   const field = createFieldDecorator(context, apiShared, optionShared, propsShared);
   const form = createFormDecorator(context, apiShared, propsShared);
-  const option = createOptionDecorator(apiShared, optionShared, propsShared);
+  const option = createOptionDecorator(context, apiShared, optionShared, propsShared);
 
   return {
     api,


### PR DESCRIPTION
This PR fixes issue with `validate` option which belongs to both `@form` and `@field` scopes. Before this PR, you were unable to use `validate` in the form because it was recognized as a "field" option and used the field initialization algorithm. 

For now, you can use `validate` in both scopes, and as a bonus code became a bit faster and cleaner.