### PR TITLE
Fix element definition timing

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -297,6 +297,17 @@ Creator function returns an `@element` decorator function that receives followin
   Basically, all the data `render` returns will be rendered to the element itself (`this` instead
   of `this.shadowRoot`).
 
+**Note**: new custom element definition with `@element` decorator is an asynchronous operation. You cannot use it
+immediately. If you need to do something with the element right after it is created, use the following approach:
+```javascript
+@element('my-component')
+class MyComponent extends HTMLElement {}
+
+await customElements.whenDefined('my-component');
+
+const myComponent = new MyComponent();
+``` 
+
 ##### Example
 ```javascript
 import {createElementDecorator, render} from '@corpuscule/element';

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -297,9 +297,6 @@ Creator function returns an `@element` decorator function that receives followin
   Basically, all the data `render` returns will be rendered to the element itself (`this` instead
   of `this.shadowRoot`).
 
-**Note**: `@element` decorator should go **ON TOP** of all other decorators. Otherwise, you could expect strange errors
-happening.
-
 ##### Example
 ```javascript
 import {createElementDecorator, render} from '@corpuscule/element';

--- a/packages/element/src/element.js
+++ b/packages/element/src/element.js
@@ -180,7 +180,12 @@ const createElementDecorator = ({renderer, scheduler = defaultScheduler}) => (
 
       constructor = target;
 
-      customElements.define(name, target, builtin && {extends: builtin});
+      // Deferring custom element definition allows to run it at the end of all
+      // decorators execution which helps to fix many issues connected with
+      // immediate custom element instance creation during definition.
+      Promise.resolve().then(() => {
+        customElements.define(name, target, builtin && {extends: builtin});
+      });
     },
     kind,
   };


### PR DESCRIPTION
This PR fixes an essential issue that happens when `@element` and other class-level decorators are used altogether. According to specification, if the document contains a custom element tag before the element is defined, during the definition new instance of this element will be created. However, it means that if the `@element` decorator is executed before some other decorators, the instance of the element will also be created before all decorators are applied to the class.

That issue leads to a bunch of potential errors and undefined behavior. This PR solves the problem by moving the custom element definition to a microtask that will be immediately executed after all synchronous code, including all other decorators, is over.

## Breaking changes
Before this PR the following operation was allowed:
```javascript
@element('my-component')
class MyComponent extends HTMLElement {}

const myComponent = new MyComponent();
```
However, with this fix to use component after it is defined, you have to wait until all microtasks are finished.
```javascript
@element('my-component')
class MyComponent extends HTMLElement {}

await customElements.whenDefined('my-component');

const myComponent = new MyComponent();
```