### PR TITLE
Fix field update before first subscription

### DIFF
--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-unbound-method
-import {defineCE, fixture} from '@open-wc/testing-helpers';
+import {defineCE, fixture, html, unsafeStatic} from '@open-wc/testing-helpers';
 import {FieldState, FieldValidator, FormApi, FormState} from 'final-form';
 import {formSpyObject, unsubscribe} from '../../../test/mocks/finalForm';
 import {createSimpleContext, CustomElement, genName} from '../../../test/utils';
@@ -414,6 +414,39 @@ const testField = () => {
       inputElement.dispatchEvent(new Event('change', {bubbles: true}));
 
       expect(state.change).not.toHaveBeenCalled();
+    });
+
+    it('does not run update before the first subscription', async () => {
+      @form()
+      class Form extends CustomElement {
+        @api public readonly formApi!: FormApi;
+        @api public readonly state!: FormState;
+
+        @option
+        public onSubmit(): void {}
+      }
+
+      @field()
+      class Field extends CustomElement {
+        @api public readonly formApi!: FormApi;
+        @api public readonly input!: FieldInputProps<string>;
+        @api public readonly meta!: FieldMetaProps;
+
+        @option public readonly name: string = 'test';
+      }
+
+      const formTag = unsafeStatic(defineCE(Form));
+      const fieldTag = unsafeStatic(defineCE(Field));
+
+      const validate = value => (value ? undefined : 'Required');
+
+      await fixture(html`
+        <${formTag}>
+          <${fieldTag} .validate="${validate}"></${fieldTag}>
+        </${formTag}>
+      `);
+
+      expect(scheduler).toHaveBeenCalledTimes(SINGLE_FIELD_UPDATE);
     });
 
     describe('@option', () => {

--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -289,11 +289,12 @@ const testField = () => {
       const [listener] = subscriptionInfo.listeners;
 
       scheduler.calls.reset();
+      scheduler.and.stub();
 
       callListener(listener, state);
       callListener(listener, state);
 
-      expect(scheduler).toHaveBeenCalledTimes(SINGLE_FIELD_UPDATE);
+      expect(scheduler).toHaveBeenCalledTimes(1);
     });
 
     it('avoids unnecessary scheduling if subscribe called many times', async () => {

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -18,7 +18,7 @@ const createField = (
   {consumer},
   {formApi, input, meta},
   options,
-  {ref, scheduler, subscribe, update},
+  {mounted, ref, scheduler, subscribe, update},
 ) => ({auto = false, selector = 'input, select, textarea'} = {}) => descriptor => {
   assertKind('field', Kind.Class, descriptor);
 
@@ -43,12 +43,13 @@ const createField = (
   let $validate;
   let $validateFields;
 
-  const $$state = Symbol();
+  const $$mounted = Symbol();
   const $$handleFocusOut = Symbol();
   const $$handleChange = Symbol();
   const $$handleFocusIn = Symbol();
   const $$ref = Symbol();
   const $$selfChange = Symbol();
+  const $$state = Symbol();
   const $$subscribe = Symbol();
   const $$subscribingValid = Symbol();
   const $$unsubscribe = Symbol();
@@ -74,11 +75,13 @@ const createField = (
               }
             }
 
-            supers[connectedCallbackKey].call(this);
-
             if (getValue(this, $name)) {
               this[$$subscribe]();
             }
+
+            supers[connectedCallbackKey].call(this);
+
+            this[$$mounted] = true;
           },
         },
         supers,
@@ -101,6 +104,10 @@ const createField = (
       ),
 
       // Private
+      $.field({
+        initializer: () => false,
+        key: $$mounted,
+      }),
       $.field({
         initializer: () => false,
         key: $$selfChange,
@@ -236,6 +243,7 @@ const createField = (
       // Static Hooks
       $.hook({
         start() {
+          mounted.set(this, $$mounted);
           ref.set(this, $$ref);
           subscribe.set(this, $$subscribe);
           update.set(this, $$update);

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -28,6 +28,7 @@ export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
     configOptions: new WeakMap(),
 
     // @field properties
+    mounted: new WeakMap(),
     ref: new WeakMap(),
     scheduler,
     subscribe: new WeakMap(),


### PR DESCRIPTION
There is an issue that occurs when you try to send an option to the Field when the `connectedCallback` hasn't been called yet. It can happen if you create your element with `document.createElement`,  assign an option property and only then appends an element to the DOM. 

Changing the regular option for the Field causes update (the same thing happens when the field state is updated). However, the subscription that is necessary for the update has its initial run in the `connectedCallback`. So, if the update runs before subscription, it leads to an error. 

This PR fixes the issue by forbidding running update before the element is connected.