### PR TITLE
Make scheduler queue-oriented

### DIFF
--- a/packages/utils/__tests__/scheduler.ts
+++ b/packages/utils/__tests__/scheduler.ts
@@ -5,6 +5,7 @@ import schedule from '../src/scheduler';
 interface TaskObject {
   readonly children: ReadonlyArray<TaskObject>;
   readonly task: () => void;
+  readonly throws?: boolean;
 }
 
 const testSchedule = () => {
@@ -23,6 +24,7 @@ const testSchedule = () => {
             {
               children: [],
               task,
+              throws: true,
             },
             {
               children: [],
@@ -62,7 +64,7 @@ const testSchedule = () => {
       const [promise, resolve] = createTestingPromise();
 
       const tree = createTaskObject(function task(this: TaskObject): void {
-        if (this.children.length === 0) {
+        if (this.throws) {
           throw new Error('foo');
         }
 

--- a/packages/utils/src/scheduler.js
+++ b/packages/utils/src/scheduler.js
@@ -1,51 +1,46 @@
-let nextTask;
+let currentNode;
+let newNode;
 
 /**
- * The function schedules tree-structured tasks where one task could generate a number of children
- * that should be executed as well. Tasks are connected via a linked list. Tree traversing
- * algorithm is depth-first and stack-oriented, so the latest task will be performed first. When
- * there are no children for the current task, it goes back for one node and checks if the task is
- * already executed. If yes, it goes back one more time - and so on. If it finds an uncompleted
- * task, it runs it and its children until all tasks in the list are completed.
+ * The function schedules tree-structured tasks where one task could generate a
+ * number of children which execution is also scheduled. Each task is connected
+ * to a parent one, and also can have a child and a sibling. Traversing
+ * algorithm is depth-first. There are two visits to the node: the first one
+ * occurs when the task is going to be performed, and the second one is when we
+ * need to resolve or reject the scheduled promise.
  *
  * If task execution runs into an error, it rejects all promises until the top one.
  */
 const walk = () => {
   let rejectionReason;
 
-  while (nextTask) {
-    const currentTask = nextTask;
-    const {completed, previous, resolve, reject, task} = currentTask;
+  while (currentNode) {
+    const {executed, resolve, reject, task} = currentNode;
 
-    if (completed) {
+    if (executed) {
       if (rejectionReason) {
         reject(rejectionReason);
+        currentNode = currentNode.parent;
+      } else {
+        resolve();
+        currentNode = currentNode.sibling || currentNode.parent;
       }
 
-      nextTask = previous;
       continue;
     }
 
     try {
-      // Task usually adds a new nextTask
+      currentNode.executed = true;
       task();
-      resolve();
-      currentTask.completed = true;
     } catch (e) {
-      reject(e);
       rejectionReason = e;
-
-      // If we have an error, we have to go back and reject all parent nodes
-      nextTask = previous;
       continue;
     }
 
-    // If task() didn't add new nextTask, we should go back to the previously
-    // added task and continue the walk
-    if (currentTask === nextTask) {
-      nextTask = previous;
-    }
+    currentNode = currentNode.child || currentNode;
   }
+
+  newNode = currentNode;
 };
 
 /**
@@ -57,17 +52,29 @@ const walk = () => {
  */
 const schedule = async task =>
   new Promise((resolve, reject) => {
-    nextTask = {
-      completed: false,
-      previous: nextTask,
+    const previousNode = newNode;
+
+    newNode = {
+      executed: false,
       reject,
       resolve,
       task,
     };
 
     // If it is the first task to execute
-    if (!nextTask.previous) {
+    if (!previousNode) {
+      currentNode = newNode;
       requestAnimationFrame(walk);
+
+      return;
+    }
+
+    if (previousNode.executed) {
+      previousNode.child = newNode;
+      newNode.parent = previousNode;
+    } else {
+      previousNode.sibling = newNode;
+      newNode.parent = previousNode.parent;
     }
   });
 


### PR DESCRIPTION
New algorithm introduced in #58 was stack-oriented: the last scheduled task is executed the first. It brings a lot of issues to a decorator interaction where different decorators use the same scheduler to perform the tasks which should run in the specific order.

This PR fixes this issue by making the algorithm queue-oriented. 