### PR TITLE
Use scheduling only on Field option change

### DIFF
--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -14,12 +14,10 @@ export const all = fieldSubscriptionItems.reduce((result, key) => {
   return result;
 }, {});
 
-const createField = (
-  {consumer},
-  {formApi, input, meta},
-  options,
-  {ref, scheduler, subscribe, update},
-) => ({auto = false, selector = 'input, select, textarea'} = {}) => descriptor => {
+const createField = ({consumer}, {formApi, input, meta}, options, {ref, schedule, scheduler}) => ({
+  auto = false,
+  selector = 'input, select, textarea',
+} = {}) => descriptor => {
   assertKind('field', Kind.Class, descriptor);
 
   const {elements, finisher = noop, kind} = descriptor;
@@ -44,17 +42,17 @@ const createField = (
   let $validateFields;
 
   const $$connected = Symbol();
+  const $$isScheduled = Symbol();
   const $$handleFocusOut = Symbol();
   const $$handleChange = Symbol();
   const $$handleFocusIn = Symbol();
   const $$ref = Symbol();
+  const $$schedule = Symbol();
   const $$selfChange = Symbol();
   const $$state = Symbol();
   const $$subscribe = Symbol();
-  const $$subscribingValid = Symbol();
   const $$unsubscribe = Symbol();
   const $$update = Symbol();
-  const $$updatingValid = Symbol();
 
   const [supers, prepareSupers] = getSupers(elements, $.lifecycleKeys);
 
@@ -105,6 +103,10 @@ const createField = (
 
       // Private
       $.field({
+        initializer: () => ({[$$schedule]: false, [$$update]: false}),
+        key: $$isScheduled,
+      }),
+      $.field({
         initializer: () => false,
         key: $$connected,
       }),
@@ -113,16 +115,8 @@ const createField = (
         key: $$selfChange,
       }),
       $.field({
-        initializer: () => true,
-        key: $$subscribingValid,
-      }),
-      $.field({
         initializer: () => noop,
         key: $$unsubscribe,
-      }),
-      $.field({
-        initializer: () => true,
-        key: $$updatingValid,
       }),
       $.accessor({
         get() {
@@ -171,72 +165,68 @@ const createField = (
         },
       }),
       $.method({
-        key: $$subscribe,
-        method() {
-          if (!this[$$subscribingValid] || !this[$$connected]) {
+        key: $$schedule,
+        method($operation) {
+          if (this[$$isScheduled][$operation] || !this[$$connected]) {
             return;
           }
 
-          this[$$subscribingValid] = false;
+          this[$$isScheduled][$operation] = true;
 
           scheduler(() => {
-            this[$$unsubscribe]();
-
-            const listener = state => {
-              this[$$state] = state;
-              this[$$update]();
-            };
-
-            this[$$unsubscribe] = getValue(this, $formApi).registerField(
-              getValue(this, $name),
-              listener,
-              ($subscription && getValue(this, $subscription)) || all,
-              {
-                getValidator: () => $validate && getValue(this, $validate),
-                isEqual: $isEqual && getValue(this, $isEqual),
-                validateFields: $validateFields && getValue(this, $validateFields),
-              },
-            );
-
-            this[$$subscribingValid] = true;
+            this[$operation]();
+            this[$$isScheduled][$operation] = false;
           });
+        },
+      }),
+      $.method({
+        key: $$subscribe,
+        method() {
+          this[$$unsubscribe]();
+
+          const listener = state => {
+            this[$$state] = state;
+            this[$$update]();
+          };
+
+          this[$$unsubscribe] = getValue(this, $formApi).registerField(
+            getValue(this, $name),
+            listener,
+            ($subscription && getValue(this, $subscription)) || all,
+            {
+              getValidator: () => $validate && getValue(this, $validate),
+              isEqual: $isEqual && getValue(this, $isEqual),
+              validateFields: $validateFields && getValue(this, $validateFields),
+            },
+          );
         },
       }),
       $.method({
         key: $$update,
         method() {
-          if (!this[$$updatingValid] || !this[$$connected]) {
-            return;
+          const format = $format && getValue(this, $format);
+
+          const {blur: _b, change: _c, focus: _f, name, length: _l, value, ...metadata} = this[
+            $$state
+          ];
+
+          const finalValue =
+            !($formatOnBlur && getValue(this, $formatOnBlur)) && format
+              ? format(value, name)
+              : value;
+
+          setValue(this, $input, {
+            name,
+            value: finalValue,
+          });
+
+          setValue(this, $meta, metadata);
+
+          if (auto && !this[$$selfChange]) {
+            setTargetValues(this[$$ref], finalValue);
           }
 
-          this[$$updatingValid] = false;
-
-          scheduler(() => {
-            const format = $format && getValue(this, $format);
-
-            const {blur: _b, change: _c, focus: _f, name, length: _l, value, ...metadata} = this[
-              $$state
-            ];
-
-            const finalValue =
-              !($formatOnBlur && getValue(this, $formatOnBlur)) && format
-                ? format(value, name)
-                : value;
-
-            setValue(this, $input, {
-              name,
-              value: finalValue,
-            });
-
-            setValue(this, $meta, metadata);
-
-            if (auto && !this[$$selfChange]) {
-              setTargetValues(this[$$ref], finalValue);
-            }
-
-            this[$$selfChange] = false;
-            this[$$updatingValid] = true;
-          });
+          this[$$selfChange] = false;
         },
       }),
 
@@ -244,8 +234,7 @@ const createField = (
       $.hook({
         start() {
           ref.set(this, $$ref);
-          subscribe.set(this, $$subscribe);
-          update.set(this, $$update);
+          schedule.set(this, [$$schedule, $$subscribe, $$update]);
         },
       }),
 

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -29,9 +29,8 @@ export const createFormContext = ({scheduler = defaultScheduler} = {}) => {
 
     // @field properties
     ref: new WeakMap(),
+    schedule: new WeakMap(),
     scheduler,
-    subscribe: new WeakMap(),
-    update: new WeakMap(),
   };
 
   const api = createApiDecorator(context, apiShared, propsShared);


### PR DESCRIPTION
For now, `@field` decorator has the following lifecycle:
1) An element is connected to the DOM and runs `connectedCallback`.
2) `connectedCallback` schedules a subscription that happens in the whole chain of scheduled tasks.
3) Subscription task schedules an update task that is put the last in the tasks chain.
4) Update task receives field state and creates `input` and `meta` objects for the element.

Well, what is wrong with this sequence? The answer is: the update task can be created only after the subscription is run. However, if we have a decorators queue where each one wraps `connectedCallback` with a specific implementation, it can create a mess. 

E.g., imagine that we have `@field` decorator and `@element` decorator from `@corpuscule/element` package:
```javascript
@field()
@element('my-element')
class MyElement extends HTMLElement {}
```
`@field`'s `connectedCallback` runs before `@element`'s one, so it successfully creates a task in the queue:
```
[subscribeTask]
``` 
Then the `@element`'s `connectedCallback` runs. It puts the `render` task to the queue.
```
[subscribeTask, renderTask]
```
And only then we come to the task execution. `subscribeTask` is executed and puts `updateTask` to the queue.
```
[subscribeTask, renderTask, updateTask]
```
Oops! Here we go. If `renderTask` uses `meta` or `input` object in some way, it will throw an error, because we don't have them yet! We can fix it by checking `input` and `meta` to be defined, but it is just a workaround hiding the real bug.

This PR address the bug described above. If we think, we can understand that using scheduling for each subscription and update is not justified, because the only reason to use them is to avoid unnecessary resubscription if several field options are changed. So, it means that we can schedule only the property changes and do everything else synchronously. 