### PR TITLE
Add tracking current route

### DIFF
--- a/packages/router/__tests__/outlet.ts
+++ b/packages/router/__tests__/outlet.ts
@@ -1,5 +1,6 @@
 // tslint:disable:max-classes-per-file
 import UniversalRouter from 'universal-router';
+import {Route} from 'universal-router/sync';
 import {createSimpleContext, createTestingPromise, CustomElement} from '../../../test/utils';
 import {api, outlet, provider} from '../src';
 
@@ -51,7 +52,7 @@ const outletTest = () => {
       [finalPromise, finalResolve] = createTestingPromise();
     });
 
-    it('creates router outlet that fills layout on popstate event', async () => {
+    it('creates router outlet that fills layout & route on popstate event', async () => {
       @provider
       class Provider extends CustomElement {
         @api public readonly router: UniversalRouter = appRouter;
@@ -61,6 +62,8 @@ const outletTest = () => {
       class Outlet extends CustomElement {
         public initial: boolean = true;
         public storage: string = '';
+
+        @api public readonly route!: Route;
 
         @api
         public get layout(): string {
@@ -94,6 +97,7 @@ const outletTest = () => {
       await finalPromise;
 
       expect(outletElement.layout).toBe('Test2');
+      expect(outletElement.route).toBe(routes[1]);
     });
 
     it("ignores path that wasn't in the routes", async () => {
@@ -112,6 +116,8 @@ const outletTest = () => {
       class Outlet extends CustomElement {
         public initial: boolean = true;
         public storage: string = '';
+
+        @api public readonly route!: Route;
 
         @api
         public get layout(): string {
@@ -162,6 +168,8 @@ const outletTest = () => {
         public initial: boolean = true;
         public storage: string = '';
 
+        @api public readonly route!: Route;
+
         @api
         public get layout(): string {
           return this.storage;
@@ -206,6 +214,7 @@ const outletTest = () => {
       @outlet(routes)
       class Outlet extends CustomElement {
         @api public readonly layout?: string;
+        @api public readonly route?: Route;
 
         public connectedCallback(): void {
           connectedSpy();
@@ -231,6 +240,7 @@ const outletTest = () => {
         // @ts-ignore
         class Outlet extends CustomElement {
           @api public readonly layout?: string;
+          @api public readonly route?: Route;
 
           public constructor() {
             super();

--- a/packages/router/src/api.js
+++ b/packages/router/src/api.js
@@ -2,19 +2,20 @@ import {assertKind, assertPlacement, Kind, Placement} from '@corpuscule/utils/li
 import {hook} from '@corpuscule/utils/lib/descriptors';
 import {getName} from '@corpuscule/utils/lib/propertyUtils';
 
-const createApiDecorator = ({value}, {api}) => descriptor => {
+const createApiDecorator = ({value}, shared) => descriptor => {
   assertKind('api', Kind.Field | Kind.Method | Kind.Accessor, descriptor);
   assertPlacement('api', Placement.Own | Placement.Prototype, descriptor);
 
   const {key} = descriptor;
+  const name = getName(key);
 
-  if (getName(key) === 'layout') {
+  if (name === 'layout' || name === 'route') {
     return {
       ...descriptor,
       extras: [
         hook({
           start() {
-            api.set(this, key);
+            shared[name].set(this, key);
           },
         }),
       ],

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -12,7 +12,8 @@ export const createRouterContext = () => {
   const context = createContext();
 
   const shared = {
-    api: new WeakMap(),
+    layout: new WeakMap(),
+    route: new WeakMap(),
   };
 
   return {

--- a/packages/router/src/outlet.js
+++ b/packages/router/src/outlet.js
@@ -12,13 +12,14 @@ const methods = [...lifecycleKeys, resolve];
 
 const [connectedCallbackKey, disconnectedCallbackKey] = lifecycleKeys;
 
-const createOutletDecorator = ({consumer, value}, {api}) => routes => descriptor => {
+const createOutletDecorator = ({consumer, value}, {layout, route}) => routes => descriptor => {
   assertKind('outlet', Kind.Class, descriptor);
 
   const {elements, finisher = noop, kind} = descriptor;
 
   let constructor;
-  let $api;
+  let $layout;
+  let $route;
 
   const getConstructor = () => constructor;
 
@@ -81,10 +82,11 @@ const createOutletDecorator = ({consumer, value}, {api}) => routes => descriptor
             return;
           }
 
-          const [result, {route}] = resolved;
+          const [result, {route: currentRoute}] = resolved;
 
-          if (routes.includes(route)) {
-            setValue(this, $api, iter.next(result).value);
+          if (routes.includes(currentRoute)) {
+            setValue(this, $route, currentRoute);
+            setValue(this, $layout, iter.next(result).value);
           }
         },
       }),
@@ -102,8 +104,10 @@ const createOutletDecorator = ({consumer, value}, {api}) => routes => descriptor
       finisher(target);
 
       constructor = target;
-      $api = api.get(target);
-      assertRequiredProperty('outlet', 'api', $api);
+      $layout = layout.get(target);
+      $route = route.get(target);
+      assertRequiredProperty('outlet', 'api', 'layout', $layout);
+      assertRequiredProperty('outlet', 'api', 'route', $route);
 
       prepareSupers(target, {
         *[resolve](path) {


### PR DESCRIPTION
This PR adds a new `route` property for the router `@outlet` that receives the current route from the list outlet has as a parameter. It opens a door for various improvements starting from the easier list of links implementation (you can now compare route with route instead of relying on `location.pathname` and other tricks) up to setting specific information in the `Route` object.