### PR TITLE
Move CustomElementRegistry patch to a separate "init.js" file

### DIFF
--- a/packages/lit-html-renderer/src/init.d.ts
+++ b/packages/lit-html-renderer/src/init.d.ts
@@ -1,0 +1,2 @@
+declare const customElementNameRegistry: WeakMap<object, string>;
+export default customElementNameRegistry;

--- a/packages/lit-html-renderer/src/init.js
+++ b/packages/lit-html-renderer/src/init.js
@@ -1,0 +1,12 @@
+const customElementNameRegistry = new WeakMap();
+
+const define = customElements.define;
+
+// Monkey-patch the customElements registry to allow using "withCustomElement"
+// with any CustomElement used in the project
+customElements.define = function(name, constructor, options) {
+  define.call(this, name, constructor, options);
+  customElementNameRegistry.set(constructor, name);
+};
+
+export default customElementNameRegistry;

--- a/packages/lit-html-renderer/src/withCustomElement.js
+++ b/packages/lit-html-renderer/src/withCustomElement.js
@@ -1,18 +1,9 @@
+import customElementNameRegistry from './init';
 import {unsafeStatic, UnsafeStatic, withUnsafeStatic} from './withUnsafeStatic';
 
 export {unsafeStatic, UnsafeStatic};
 
-const customElementNameRegistry = new WeakMap();
 const cache = new WeakMap();
-
-const define = customElements.define;
-
-// Monkey-patch the customElements registry to allow using "withCustomElement"
-// with any CustomElement used in the project
-customElements.define = function(name, constructor, options) {
-  define.call(this, name, constructor, options);
-  customElementNameRegistry.set(constructor, name);
-};
 
 const withCustomElement = processor => {
   const processorWithUnsafeStatic = withUnsafeStatic(processor);


### PR DESCRIPTION
This PR moves `CustomElementRegistry` patch to a separate file. It allows using `withCustomElement` function with any Custom Element in the project even if they are declared in third-party packages. All you need to put the `@corpuscule/lit-html-renderer/init` as the first importing file of the whole package. So the registry patch will be performed at the very start, and any Custom Element will be accessible via `customElementNameRegistry` map. 