### PR TITLE
Add init file to the files list

### DIFF
--- a/scripts/project.js
+++ b/scripts/project.js
@@ -2,7 +2,7 @@ const packages = {
   context: ['index'],
   element: ['index'],
   form: ['index'],
-  'lit-html-renderer': ['index', 'shady', 'withCustomElement'],
+  'lit-html-renderer': ['index', 'init', 'shady', 'withCustomElement'],
   redux: ['index'],
   router: ['index'],
   styles: ['index'],


### PR DESCRIPTION
This PR fixes mistake from #71: it adds `init.js` file to the list of separate files to allow importing it separately.