### PR TITLE
Tune karma configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ node_js:
 cache:
   directories:
   - $HOME/.npm
-script: npm test
+script: npm run test:coverage
 after_success:
   - ./node_modules/.bin/codecov -e TRAVIS_NODE_VERSION -f .coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "prepare": "run-s bootstrap build lint",
     "prepublish": "run-s build",
     "prettier": "prettier --write \"{packages,scripts,test}/**/*.{js,ts}\"",
-    "test": "karma start test/karma.conf.js"
+    "test": "karma start test/karma.conf.js",
+    "test:watch": "npm run test -- --watch",
+    "test:coverage": "npm run test -- --coverage"
   },
   "repository": {
     "type": "git",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -4,6 +4,7 @@
 const webpack = require('./webpack.config');
 
 const isCI = !!process.env.CI;
+const watch = !!process.argv.find(arg => arg.includes('watch')) && !isCI;
 
 module.exports = config => {
   config.set({
@@ -51,7 +52,7 @@ module.exports = config => {
     logLevel: config.LOG_INFO,
 
     // Enable / disable watching file and executing test whenever any file changes
-    autoWatch: !isCI,
+    autoWatch: watch,
 
     // Start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
@@ -59,7 +60,7 @@ module.exports = config => {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the test and exits
-    singleRun: isCI,
+    singleRun: !watch,
 
     // Concurrency level
     // how many browser should be started simultaneous

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -1,6 +1,8 @@
 /* eslint-disable sort-keys */
 const {resolve} = require('path');
 
+const coverage = process.argv.find(arg => arg.includes('coverage'));
+
 module.exports = {
   devtool: 'inline-source-map',
   mode: 'development',
@@ -18,7 +20,7 @@ module.exports = {
       {
         test: /\.js/,
         use: [
-          {
+          coverage && {
             loader: 'istanbul-instrumenter-loader',
             options: {
               esModules: true,
@@ -33,7 +35,7 @@ module.exports = {
               plugins: [require('@babel/plugin-proposal-class-properties')],
             },
           },
-        ],
+        ].filter(Boolean),
         include: /packages/,
         exclude: /node_modules|__tests__|lib/,
       },


### PR DESCRIPTION
This PR improves karma configuration with adding the following CLI keys:
* `--coverage` — to enable istanbul coverage.
* `--watch` — to enable karma watching.