### PR TITLE
Make defaultValue for provider undefined instead of null

### DIFF
--- a/packages/context/__tests__/index.ts
+++ b/packages/context/__tests__/index.ts
@@ -275,6 +275,21 @@ describe('@corpuscule/context', () => {
     expect(isProvider(token, Consumer)).not.toBeTruthy();
   });
 
+  it('sends undefined if there is not value set', async () => {
+    @provider
+    class Provider extends CustomElement {
+      @value public providingValue: undefined;
+    }
+
+    @consumer
+    class Consumer extends CustomElement {
+      @value public contextValue: undefined;
+    }
+
+    const [, consumerElement] = await createSimpleContext(Provider, Consumer);
+    expect(consumerElement.contextValue).toBeUndefined();
+  });
+
   it('throws an error if no provider exists for context', done => {
     @consumer
     class Consumer extends CustomElement {

--- a/packages/context/src/provider.js
+++ b/packages/context/src/provider.js
@@ -3,7 +3,7 @@ import defineExtendable from '@corpuscule/utils/lib/defineExtendable';
 import {setObject} from '@corpuscule/utils/lib/setters';
 import {getSupers, tokenRegistry} from './utils';
 
-const provider = (token, defaultValue = null) => target => {
+const provider = (token, defaultValue) => target => {
   let $value;
 
   const {prototype} = target;


### PR DESCRIPTION
This PR makes `defaultValue` argument of the `@provider` decorator `undefined` by default. This fix is important because `null` blocks the ES6 default assign that can be applied to a setter of the consumer's `contextValue` property. 

## Breaking changes
All the code relied to the default `null` value should be changed to use `undefined` now.