### PR TITLE
Fix timing of calling [stylesAttachedCallback] for URL instances

### DIFF
--- a/packages/styles/__tests__/index.ts
+++ b/packages/styles/__tests__/index.ts
@@ -9,6 +9,14 @@ const createSimpleElement = <T extends Element>(cls: Constructor<T>): T => {
   return fixtureSync<T>(`<${tag}></${tag}>`);
 };
 
+const emulateCssFileLoadingSuccess = (observationTarget: HTMLElement | ShadowRoot) => {
+  const observer = new MutationObserver(([record]: MutationRecord[]) => {
+    record.addedNodes[0].dispatchEvent(new Event('load'));
+  });
+
+  observer.observe(observationTarget, {childList: true});
+};
+
 describe('@corpuscule/styles', () => {
   const rawStyles = '.foo{color: red;}';
   let styles: typeof defaultStyles;
@@ -40,6 +48,8 @@ describe('@corpuscule/styles', () => {
 
       const test = createSimpleElement(Test);
 
+      emulateCssFileLoadingSuccess(test.shadowRoot!);
+
       await promise;
 
       expect(test.shadowRoot!.innerHTML).toBe(
@@ -67,6 +77,8 @@ describe('@corpuscule/styles', () => {
       }
 
       const test = createSimpleElement(Test);
+
+      emulateCssFileLoadingSuccess(test.shadowRoot!);
 
       await promise;
 

--- a/packages/styles/src/index.d.ts
+++ b/packages/styles/src/index.d.ts
@@ -1,14 +1,14 @@
 export const stylesAttachedCallback: unique symbol;
 
 export interface StylesDecoratorOptions {
-  readonly adoptedStyleSheets: boolean;
-  readonly shadyCSS: boolean;
+  readonly adoptedStyleSheets?: boolean;
+  readonly shadyCSS?: boolean;
 }
 
-export const stylesAdvanced: <T extends Array<string | URL>>(
-  options: StylesDecoratorOptions,
-  ...pathsOrStyles: T
+export const stylesAdvanced: (
+  pathsOrStyles: Array<string | URL>,
+  options?: StylesDecoratorOptions,
 ) => ClassDecorator;
 
-declare const styles: <T extends Array<string | URL>>(...pathsOrStyles: T) => ClassDecorator;
+declare const styles: (...pathsOrStyles: Array<string | URL>) => ClassDecorator;
 export default styles;

--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -5,9 +5,16 @@ export const stylesAttachedCallback = Symbol();
 
 const observerConfig = {childList: true};
 
-export const stylesAdvanced = ({shadyCSS, adoptedStyleSheets}, ...pathsOrStyles) => target => {
+export const stylesAdvanced = (
+  pathsOrStyles,
+  {
+    adoptedStyleSheets = 'adoptedStyleSheets' in Document.prototype,
+    shadyCSS = window.ShadyCSS !== undefined && !window.ShadyCSS.nativeShadow,
+  } = {},
+) => target => {
   const {prototype} = target;
-  const fragment = document.createDocumentFragment();
+  const linkNodes = document.createDocumentFragment();
+  const styleNodes = document.createDocumentFragment();
   const constructableStyles = [];
 
   for (const pathOrStyle of pathsOrStyles) {
@@ -20,7 +27,7 @@ export const stylesAdvanced = ({shadyCSS, adoptedStyleSheets}, ...pathsOrStyles)
         pathOrStyle.origin === location.origin
           ? pathOrStyle.pathname + pathOrStyle.search
           : pathOrStyle;
-      fragment.appendChild(link);
+      linkNodes.append(link);
     } else if (shadyCSS) {
       // If ShadyCSS
       constructableStyles.push(pathOrStyle);
@@ -33,7 +40,7 @@ export const stylesAdvanced = ({shadyCSS, adoptedStyleSheets}, ...pathsOrStyles)
       // Otherwise, just create a style tag
       const style = document.createElement('style');
       style.textContent = pathOrStyle;
-      fragment.appendChild(style);
+      styleNodes.append(style);
     }
   }
 
@@ -50,20 +57,16 @@ export const stylesAdvanced = ({shadyCSS, adoptedStyleSheets}, ...pathsOrStyles)
       }
     }
 
-    if (fragment.hasChildNodes()) {
-      const elements = fragment.cloneNode(true);
-      const links = elements.querySelectorAll('link');
-
+    if (linkNodes.hasChildNodes() || styleNodes.hasChildNodes()) {
       const observer = new MutationObserver(() => {
-        root.prepend(elements);
-        observer.disconnect();
+        root.prepend(styleNodes.cloneNode(true));
 
-        if (links.length > 0) {
-          let count = links.length;
+        if (linkNodes.hasChildNodes()) {
+          const nodesToAppend = linkNodes.cloneNode(true);
 
-          for (const link of links) {
+          for (let i = 0, count = nodesToAppend.children.length; i < count; i++) {
             // eslint-disable-next-line no-loop-func
-            link.addEventListener('load', () => {
+            nodesToAppend.children[i].addEventListener('load', () => {
               count -= 1;
 
               if (count === 0) {
@@ -71,9 +74,13 @@ export const stylesAdvanced = ({shadyCSS, adoptedStyleSheets}, ...pathsOrStyles)
               }
             });
           }
+
+          root.prepend(nodesToAppend);
         } else {
           supers[stylesAttachedCallback].call(this);
         }
+
+        observer.disconnect();
       });
 
       observer.observe(root, observerConfig);
@@ -85,11 +92,6 @@ export const stylesAdvanced = ({shadyCSS, adoptedStyleSheets}, ...pathsOrStyles)
   };
 };
 
-const defaultOptions = {
-  adoptedStyleSheets: 'adoptedStyleSheets' in Document.prototype,
-  shadyCSS: window.ShadyCSS !== undefined && !window.ShadyCSS.nativeShadow,
-};
-
-const styles = (...pathsOrStyles) => stylesAdvanced(defaultOptions, ...pathsOrStyles);
+const styles = (...pathsOrStyles) => stylesAdvanced(pathsOrStyles);
 
 export default styles;

--- a/test/assets/styles/basic.css
+++ b/test/assets/styles/basic.css
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -23,7 +23,16 @@ module.exports = config => {
     frameworks: ['jasmine'],
 
     // List of files / patterns to load in the browser
-    files: ['test/test.js'],
+    files: [
+      'test/test.js',
+      {
+        pattern: './test/assets/**/*',
+        watched: false,
+        included: false,
+        nocache: false,
+        served: true,
+      },
+    ],
 
     // List of files / patterns to exclude
     exclude: [],
@@ -67,6 +76,10 @@ module.exports = config => {
     concurrency: Infinity,
 
     webpack,
+
+    proxies: {
+      '/assets/': '/base/test/assets/',
+    },
 
     coverageIstanbulReporter: {
       reports: ['html', 'lcovonly'],


### PR DESCRIPTION
This PR fixes the timing when `[stylesAttachedCallback]` is called for styles loaded via `URL` instances. Before it was called when the root is changed. It is suitable for the `<styles>` element but does not work for the `<link>` which should wait until the CSS file is loaded.