### PR TITLE
Small improvements for the element

### DIFF
--- a/packages/element/__tests__/element.ts
+++ b/packages/element/__tests__/element.ts
@@ -385,6 +385,22 @@ describe('@corpuscule/element', () => {
       }).not.toThrow();
     });
 
+    it('allows omitting renderer option', async () => {
+      const tag = genName();
+
+      @basicElement(tag, {scheduler: schedulerSpy})
+      // @ts-ignore
+      class Test extends fixtureMixin(CustomElement) {
+        public [render](): string {
+          return 'render';
+        }
+      }
+
+      await fixture(`<${tag}></${tag}>`);
+
+      expect(schedulerSpy).not.toHaveBeenCalled();
+    });
+
     describe('elements extending', () => {
       it('allows extending existing element', async () => {
         const tag1 = genName();

--- a/packages/element/src/element.js
+++ b/packages/element/src/element.js
@@ -117,7 +117,7 @@ const element = (
   // Deferring custom element definition allows to run it at the end of all
   // decorators execution which helps to fix many issues connected with
   // immediate custom element instance creation during definition.
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     customElements.define(name, klass, builtin && {extends: builtin});
   });
 };

--- a/packages/element/src/element.js
+++ b/packages/element/src/element.js
@@ -21,7 +21,6 @@ const element = (
   {extends: builtin, lightDOM, renderer, scheduler = defaultScheduler} = {},
 ) => klass => {
   const {prototype} = klass;
-  const hasRender = $render in prototype;
   const isLight = lightDOM || (builtin && !shadowElements.includes(builtin));
 
   const $$connected = Symbol();
@@ -70,24 +69,25 @@ const element = (
   );
 
   Object.assign(prototype, {
-    [$$invalidate]: hasRender
-      ? async function() {
-          if (!this[$$valid]) {
-            return;
+    [$$invalidate]:
+      $render in prototype && renderer
+        ? async function() {
+            if (!this[$$valid]) {
+              return;
+            }
+
+            this[$$valid] = false;
+
+            await scheduler(() => {
+              renderer(this[$render](), this[$$root], this);
+              this[$$valid] = true;
+            });
+
+            if (this[$$connected]) {
+              this[$updatedCallback]();
+            }
           }
-
-          this[$$valid] = false;
-
-          await scheduler(() => {
-            renderer(this[$render](), this[$$root], this);
-            this[$$valid] = true;
-          });
-
-          if (this[$$connected]) {
-            this[$updatedCallback]();
-          }
-        }
-      : noop,
+        : noop,
     async [$internalChangedCallback](internalName, oldValue, newValue) {
       if (!this[$$connected]) {
         return;

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -98,7 +98,7 @@ export interface ElementDecoratorOptions {
    * This option defines the rendering function that applies result returned
    * from the [[render]] function to the component body.
    *
-   * If you omit this property, re-rendering won't ever happen on your element.
+   * If you omit this property, rendering won't ever happen on your element.
    *
    * @param renderingResult a result returned by a [[render]] function.
    *
@@ -440,7 +440,7 @@ export const propertyChangedCallback: unique symbol;
  * will be handled by a [renderer]{@link ElementDecoratorOptions.renderer}
  * function.
  *
- * If you do not specify this method, re-rendering won't ever happen on your
+ * If you do not define this method, rendering won't ever happen on your
  * element.
  *
  * ### Method signature

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -98,6 +98,8 @@ export interface ElementDecoratorOptions {
    * This option defines the rendering function that applies result returned
    * from the [[render]] function to the component body.
    *
+   * If you omit this property, re-rendering won't ever happen on your element.
+   *
    * @param renderingResult a result returned by a [[render]] function.
    *
    * @param container a component root to which result should be applied. It
@@ -108,7 +110,11 @@ export interface ElementDecoratorOptions {
    * setting the [eventContext](https://lit-html.polymer-project.org/api/interfaces/lit_html.renderoptions.html#eventcontext)
    * of lit-html.
    */
-  renderer(renderingResult: unknown, container: Element | DocumentFragment, context: unknown): void;
+  renderer?(
+    renderingResult: unknown,
+    container: Element | DocumentFragment,
+    context: unknown,
+  ): void;
 
   /**
    * This option defines the function that schedules the rendering process.

--- a/packages/element/src/property.js
+++ b/packages/element/src/property.js
@@ -1,14 +1,14 @@
 import makeAccessor from '@corpuscule/utils/lib/makeAccessor';
 import {propertyChangedCallback as $propertyChangedCallback} from './tokens';
 
-const property = (guard = null) => ({constructor: klass}, propertyKey, descriptor) => {
+const property = (guard = () => true) => ({constructor: klass}, propertyKey, descriptor) => {
   const {get, set} = makeAccessor(descriptor, klass.__initializers);
 
   return {
     configurable: true,
     get,
     set(value) {
-      if (guard && !guard(value)) {
+      if (!guard(value)) {
         throw new TypeError(`Value applied to "${propertyKey}" has wrong type`);
       }
 


### PR DESCRIPTION
This PR introduces several small changes to the `@corpuscule/element` package:
* `renderer` option of the `ElementDecoratorOptions` is not required anymore. If you omit this property, no rendering will ever happen to you element.
* `queueMicrotask` is used instead of the `Promise.resolve`. It is a modern analogue to the `Promise.resolve` and describes the action it performs better.
* `guard` parameter of the `@property` decorator is the function by default now. It allows avoiding unnecessary and expensive null check on the property change.