### PR TITLE
Allow specifying a custom name for the gear and option properties

### DIFF
--- a/packages/form/__tests__/field.ts
+++ b/packages/form/__tests__/field.ts
@@ -63,20 +63,20 @@ describe('@corpuscule/form', () => {
     it('creates field that receives form', async () => {
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<string>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<string>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
       }
 
       const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -90,20 +90,20 @@ describe('@corpuscule/form', () => {
 
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<string>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<string>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
 
         public connectedCallback(): void {
           connectedCallbackSpy(this.formApi);
@@ -118,32 +118,32 @@ describe('@corpuscule/form', () => {
     it('subscribes to form with defined options', async () => {
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<string>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<string>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
 
-        @option
+        @option()
         public isEqual(): boolean {
           return true;
         }
 
-        @option
+        @option()
         public validate(): boolean {
           return true;
         }
 
-        @option
+        @option()
         public validateFields(): boolean {
           return true;
         }
@@ -165,20 +165,20 @@ describe('@corpuscule/form', () => {
     it('creates new input and meta objects on each form update', async () => {
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<object>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<object>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
       }
 
       const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -196,25 +196,25 @@ describe('@corpuscule/form', () => {
 
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<object>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<object>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
 
-        @option
+        @option()
         public formatOnBlur: boolean = false;
 
-        @option
+        @option()
         public format(value: unknown, name: string): unknown {
           formatSpy(value, name);
 
@@ -232,20 +232,20 @@ describe('@corpuscule/form', () => {
 
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<object>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<object>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public name: string = 'test';
+        @option() public name: string = 'test';
       }
 
       const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -258,20 +258,20 @@ describe('@corpuscule/form', () => {
     it('unsubscribes on disconnectedCallback', async () => {
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<object>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<object>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
       }
 
       const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -288,20 +288,20 @@ describe('@corpuscule/form', () => {
 
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<object>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<object>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public name: string = 'test';
+        @option() public name: string = 'test';
       }
 
       const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -314,20 +314,20 @@ describe('@corpuscule/form', () => {
     it('does not change form value if event is not custom and field is not auto', async () => {
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<string>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<string>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
       }
 
       const formTag = defineCE(Form);
@@ -352,20 +352,20 @@ describe('@corpuscule/form', () => {
     it('does not run update before the first subscription', async () => {
       @form()
       class Form extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
       @field()
       class Field extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly input!: FieldInputProps<string>;
-        @gear public readonly meta!: FieldMetaProps<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly input!: FieldInputProps<string>;
+        @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-        @option public readonly name: string = 'test';
+        @option() public readonly name: string = 'test';
       }
 
       const formTag = unsafeStatic(defineCE(Form));
@@ -386,20 +386,20 @@ describe('@corpuscule/form', () => {
       it('resubscribes on name value change', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field()
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option
+          @option()
           public name: string = 'test1';
         }
 
@@ -413,20 +413,20 @@ describe('@corpuscule/form', () => {
       it('does not resubscribe on name change if option values are equal', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field()
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public name: string = 'test1';
+          @option() public name: string = 'test1';
         }
 
         const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -439,21 +439,21 @@ describe('@corpuscule/form', () => {
       it('resubscribes on subscription value change', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field()
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public name: string = 'test';
-          @option public subscription: Record<string, boolean> = all;
+          @option() public name: string = 'test';
+          @option() public subscription: Record<string, boolean> = all;
         }
 
         const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -466,21 +466,21 @@ describe('@corpuscule/form', () => {
       it('does not resubscribe on subscription change if option values are equal', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field()
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public name: string = 'test';
-          @option public subscription: Record<string, boolean> = all;
+          @option() public name: string = 'test';
+          @option() public subscription: Record<string, boolean> = all;
         }
 
         const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -495,13 +495,13 @@ describe('@corpuscule/form', () => {
           @field()
           // @ts-ignore
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
 
-            @option
+            @option()
             public test: string = 'test';
           }
         }).toThrow(
@@ -514,9 +514,9 @@ describe('@corpuscule/form', () => {
           @field()
           // @ts-ignore
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
           }
         }).toThrowError('@field requires name property marked with @option');
       });
@@ -524,20 +524,20 @@ describe('@corpuscule/form', () => {
       it('does not run registerField on connection if name has no value', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field()
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<string>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<string>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public readonly name?: string;
+          @option() public readonly name?: string;
         }
 
         const formTag = defineCE(Form);
@@ -555,22 +555,22 @@ describe('@corpuscule/form', () => {
       it('properly sets validate option', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field()
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<string>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<string>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public readonly name: string = 'test';
+          @option() public readonly name: string = 'test';
 
-          @option
+          @option()
           public validate(): void {}
         }
 
@@ -589,6 +589,35 @@ describe('@corpuscule/form', () => {
 
         expect(getValidator()).toBe(fieldElement.validate);
       });
+
+      it('allows using specific name of the property along with the responsibility key', async () => {
+        @form()
+        class Form extends CustomElement {
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
+
+          @option()
+          public onSubmit(): void {}
+        }
+
+        @field()
+        class Field extends CustomElement {
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
+
+          @option('name') public readonly n: string = 'test';
+        }
+
+        await createSimpleContext(Form, Field);
+
+        expect(formSpyObject.registerField).toHaveBeenCalledWith(
+          'test',
+          jasmine.any(Function),
+          all,
+          jasmine.any(Object),
+        );
+      });
     });
 
     describe('@gear', () => {
@@ -603,7 +632,7 @@ describe('@corpuscule/form', () => {
           @field()
           // @ts-ignore
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
+            @gear() public readonly formApi!: FormApi;
           }
         }).toThrowError('@field requires input property marked with @gear');
 
@@ -611,8 +640,8 @@ describe('@corpuscule/form', () => {
           @field()
           // @ts-ignore
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
           }
         }).toThrowError('@field requires meta property marked with @gear');
       });
@@ -620,10 +649,10 @@ describe('@corpuscule/form', () => {
       it('allows using accessors for all gear elements', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
@@ -631,7 +660,7 @@ describe('@corpuscule/form', () => {
         class Field extends CustomElement {
           public storage!: FormApi;
 
-          @gear
+          @gear()
           public get formApi(): FormApi {
             return this.storage;
           }
@@ -640,10 +669,10 @@ describe('@corpuscule/form', () => {
             this.storage = v;
           }
 
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public readonly name: string = 'test';
+          @option() public readonly name: string = 'test';
         }
 
         const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -656,9 +685,9 @@ describe('@corpuscule/form', () => {
           @form()
           // @ts-ignore
           class Form extends CustomElement {
-            @gear public readonly notForm!: FormApi;
+            @gear() public readonly notForm!: FormApi;
 
-            @option
+            @option()
             public onSubmit(): void {}
           }
         }).toThrow(new TypeError('Property name notForm is not allowed'));
@@ -667,9 +696,9 @@ describe('@corpuscule/form', () => {
           @field()
           // @ts-ignore
           class Field extends CustomElement {
-            @gear public readonly notInput!: FieldInputProps<object>;
+            @gear() public readonly notInput!: FieldInputProps<object>;
 
-            @option
+            @option()
             public onSubmit(): void {}
           }
         }).toThrow(new TypeError('Property name notInput is not allowed'));
@@ -679,20 +708,20 @@ describe('@corpuscule/form', () => {
         it('calls blur() method of field state if the "focusout" event is fired', async () => {
           @form()
           class Form extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly state!: FormState<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly state!: FormState<unknown>;
 
-            @option
+            @option()
             public onSubmit(): void {}
           }
 
           @field()
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -705,25 +734,25 @@ describe('@corpuscule/form', () => {
         it('formats and sets value on blur if appropriate options are set', async () => {
           @form()
           class Form extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly state!: FormState<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly state!: FormState<unknown>;
 
-            @option
+            @option()
             public onSubmit(): void {}
           }
 
           @field()
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
 
-            @option
+            @option()
             public formatOnBlur: boolean = true;
 
-            @option
+            @option()
             public format(value: unknown): unknown {
               return value;
             }
@@ -742,20 +771,20 @@ describe('@corpuscule/form', () => {
         it('calls change() method of field state when new "change" event is fired', async () => {
           @form()
           class Form extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly state!: FormState<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly state!: FormState<unknown>;
 
-            @option
+            @option()
             public onSubmit(): void {}
           }
 
           @field()
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -770,22 +799,22 @@ describe('@corpuscule/form', () => {
         it('parses value if parse option is defined', async () => {
           @form()
           class Form extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly state!: FormState<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly state!: FormState<unknown>;
 
-            @option
+            @option()
             public onSubmit(): void {}
           }
 
           @field()
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
 
-            @option
+            @option()
             public parse(value: string): object {
               return JSON.parse(value);
             }
@@ -806,20 +835,20 @@ describe('@corpuscule/form', () => {
         it('calls focus() method of field stat if "focusin" event is fired', async () => {
           @form()
           class Form extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly state!: FormState<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly state!: FormState<unknown>;
 
-            @option
+            @option()
             public onSubmit(): void {}
           }
 
           @field()
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const [, fieldElement] = await createSimpleContext(Form, Field);
@@ -833,20 +862,20 @@ describe('@corpuscule/form', () => {
       it('catches event even if it is fired not in the component itself', async () => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field()
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public readonly name: string = 'test';
+          @option() public readonly name: string = 'test';
         }
 
         const fieldTag = defineCE(Field);
@@ -866,6 +895,32 @@ describe('@corpuscule/form', () => {
 
         expect(state.focus).toHaveBeenCalled();
       });
+
+      it('allows using specific name of the property along with the responsibility key', async () => {
+        @form()
+        class Form extends CustomElement {
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
+
+          @option()
+          public onSubmit(): void {}
+        }
+
+        @field()
+        class Field extends CustomElement {
+          @gear('formApi') public readonly fa!: FormApi;
+          @gear('input') public readonly i!: FieldInputProps<object>;
+          @gear('meta') public readonly m!: FieldMetaProps<unknown>;
+
+          @option() public readonly name: string = 'test';
+        }
+
+        const [, fieldElement] = await createSimpleContext(Form, Field);
+
+        expect(fieldElement.fa).toBe(formSpyObject);
+        expect(fieldElement.i).toEqual({name: 'test', value: fieldValue});
+        expect(fieldElement.m).toEqual(metaObject);
+      });
     });
 
     describe('auto fields', () => {
@@ -875,20 +930,20 @@ describe('@corpuscule/form', () => {
       beforeEach(() => {
         @form()
         class Form extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
 
         @field({auto: true})
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-          @option public readonly name: string = 'test';
+          @option() public readonly name: string = 'test';
         }
 
         formTag = defineCE(Form);
@@ -900,12 +955,12 @@ describe('@corpuscule/form', () => {
       it('allows to define ref property for container', async () => {
         @field({auto: true})
         class Field extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly input!: FieldInputProps<object>;
-          @gear public readonly meta!: FieldMetaProps<unknown>;
-          @gear public readonly refs!: NodeListOf<HTMLInputElement>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly input!: FieldInputProps<object>;
+          @gear() public readonly meta!: FieldMetaProps<unknown>;
+          @gear() public readonly refs!: NodeListOf<HTMLInputElement>;
 
-          @option public readonly name: string = 'test';
+          @option() public readonly name: string = 'test';
         }
 
         const tag = defineCE(Field);
@@ -929,11 +984,11 @@ describe('@corpuscule/form', () => {
           @field()
           // @ts-ignore
           class Field extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<string>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<string>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
 
             public constructor() {
               super();
@@ -1014,11 +1069,11 @@ describe('@corpuscule/form', () => {
         it('allows HTMLInputElement to update form value', async () => {
           @field({auto: true})
           class Field extends HTMLInputElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const nativeFieldTag = genName();
@@ -1041,11 +1096,11 @@ describe('@corpuscule/form', () => {
         it('allows HTMLInputElement updating on form change', async () => {
           @field({auto: true})
           class Field extends HTMLInputElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const nativeFieldTag = genName();
@@ -1234,11 +1289,11 @@ describe('@corpuscule/form', () => {
         it('allows HTMLInputElement to update form value', async () => {
           @field({auto: true})
           class Field extends HTMLInputElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const nativeFieldTag = genName();
@@ -1260,11 +1315,11 @@ describe('@corpuscule/form', () => {
         it('allows HTMLInputElement updating on form change', async () => {
           @field({auto: true})
           class Field extends HTMLInputElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const nativeFieldTag = genName();
@@ -1358,11 +1413,11 @@ describe('@corpuscule/form', () => {
         it('allows HTMLInputElement to update form value', async () => {
           @field({auto: true})
           class Field extends HTMLInputElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const nativeFieldTag = genName();
@@ -1390,11 +1445,11 @@ describe('@corpuscule/form', () => {
         it('allows HTMLInputElement updating on form change', async () => {
           @field({auto: true})
           class Field extends HTMLInputElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly input!: FieldInputProps<object>;
-            @gear public readonly meta!: FieldMetaProps<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly input!: FieldInputProps<object>;
+            @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-            @option public readonly name: string = 'test';
+            @option() public readonly name: string = 'test';
           }
 
           const nativeFieldTag = genName();
@@ -1516,11 +1571,11 @@ describe('@corpuscule/form', () => {
           beforeEach(async () => {
             @field({auto: true})
             class Field extends HTMLSelectElement {
-              @gear public readonly formApi!: FormApi;
-              @gear public readonly input!: FieldInputProps<object>;
-              @gear public readonly meta!: FieldMetaProps<unknown>;
+              @gear() public readonly formApi!: FormApi;
+              @gear() public readonly input!: FieldInputProps<object>;
+              @gear() public readonly meta!: FieldMetaProps<unknown>;
 
-              @option public readonly name: string = 'test';
+              @option() public readonly name: string = 'test';
             }
 
             const nativeFieldTag = genName();

--- a/packages/form/__tests__/form.ts
+++ b/packages/form/__tests__/form.ts
@@ -23,13 +23,13 @@ describe('@corpuscule/form', () => {
     it('allows to declare form configuration with decorator', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public debug: boolean = true;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -47,14 +47,14 @@ describe('@corpuscule/form', () => {
 
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
         public call(): void {
           submitSpy();
         }
 
-        @option
+        @option()
         public onSubmit(): void {
           this.call();
         }
@@ -76,12 +76,12 @@ describe('@corpuscule/form', () => {
     it('allows to declare configuration on full accessor', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
         public secret: boolean = true;
 
-        @option
+        @option()
         public get debug(): boolean {
           return this.secret;
         }
@@ -90,7 +90,7 @@ describe('@corpuscule/form', () => {
           this.secret = v;
         }
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -106,13 +106,13 @@ describe('@corpuscule/form', () => {
     it('allows to update form data with defined properties', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public debug: boolean = true;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -127,13 +127,13 @@ describe('@corpuscule/form', () => {
     it('does not update property if it is the same', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public debug: boolean = true;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -150,13 +150,13 @@ describe('@corpuscule/form', () => {
         @form()
         // @ts-ignore
         class Test extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public test: boolean = true;
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
       }).toThrow(new TypeError('"test" is not one of the Final Form or Field configuration keys'));
@@ -165,16 +165,16 @@ describe('@corpuscule/form', () => {
     it('initializes form if new "initialValues" are set', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public initialValues: object = {
           bar: 2,
           foo: 1,
         };
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -195,16 +195,16 @@ describe('@corpuscule/form', () => {
     it('checks shallow equality by default for initialValues', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public initialValues: object = {
           bar: 2,
           foo: 1,
         };
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -224,23 +224,23 @@ describe('@corpuscule/form', () => {
 
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public initialValues: object = {
           bar: 2,
           foo: 1,
         };
 
-        @option
+        @option()
         public compareInitialValues<T extends {foo: number}>(a: T, b: T): boolean {
           compareInitialValuesSpy();
 
           return a.foo === b.foo;
         }
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -264,13 +264,13 @@ describe('@corpuscule/form', () => {
     it('sets default undefined if option exists but not set', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public debug?: boolean;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -291,10 +291,10 @@ describe('@corpuscule/form', () => {
         decorators: [decorate],
       })
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -310,10 +310,10 @@ describe('@corpuscule/form', () => {
     it('subscribes to the form on connection, unsubscribes on disconnection and sets form state', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -336,10 +336,10 @@ describe('@corpuscule/form', () => {
     it('catches submit event', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -360,10 +360,10 @@ describe('@corpuscule/form', () => {
     it('catches reset event', async () => {
       @form()
       class Test extends CustomElement {
-        @gear public readonly formApi!: FormApi;
-        @gear public readonly state!: FormState<unknown>;
+        @gear() public readonly formApi!: FormApi;
+        @gear() public readonly state!: FormState<unknown>;
 
-        @option
+        @option()
         public onSubmit(): void {}
       }
 
@@ -393,9 +393,28 @@ describe('@corpuscule/form', () => {
           @form()
           // @ts-ignore
           class FormField extends CustomElement {
-            @gear public readonly formApi!: FormApi;
+            @gear() public readonly formApi!: FormApi;
           }
         }).toThrowError('@form requires state property marked with @gear');
+      });
+
+      it('allows using specific name of the property along with the responsibility key', async () => {
+        @form()
+        class Test extends CustomElement {
+          @gear('formApi') public readonly fa!: FormApi;
+          @gear('state') public readonly s!: FormState<unknown>;
+
+          @option()
+          public debug: boolean = true;
+
+          @option()
+          public onSubmit(): void {}
+        }
+
+        const tag = defineCE(Test);
+        const test = await fixture<Test>(`<${tag}></${tag}>`);
+
+        expect(test.fa).toBe(formSpyObject);
       });
     });
 
@@ -405,8 +424,8 @@ describe('@corpuscule/form', () => {
           @form()
           // @ts-ignore
           class Test extends CustomElement {
-            @gear public readonly formApi!: FormApi;
-            @gear public readonly state!: FormState<unknown>;
+            @gear() public readonly formApi!: FormApi;
+            @gear() public readonly state!: FormState<unknown>;
           }
         }).toThrowError('@form requires onSubmit property marked with @option');
       });
@@ -414,13 +433,13 @@ describe('@corpuscule/form', () => {
       it('properly sets validate option', async () => {
         @form()
         class Test extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
-          @option
+          @option()
           public onSubmit(): void {}
 
-          @option
+          @option()
           public validate(): void {}
         }
 
@@ -431,6 +450,28 @@ describe('@corpuscule/form', () => {
 
         expect(validate).toBe(test.validate);
       });
+
+      it('allows using specific name of the property along with the responsibility key', async () => {
+        @form()
+        class Test extends CustomElement {
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
+
+          @option('debug')
+          public d: boolean = true;
+
+          @option('onSubmit')
+          public os(): void {}
+        }
+
+        const tag = defineCE(Test);
+        await fixture(`<${tag}></${tag}>`);
+
+        expect(createForm).toHaveBeenCalledWith({
+          debug: true,
+          onSubmit: jasmine.any(Function),
+        });
+      });
     });
 
     it('does not throw an error if class already have own lifecycle element', () => {
@@ -438,8 +479,8 @@ describe('@corpuscule/form', () => {
         @form()
         // @ts-ignore
         class Test extends CustomElement {
-          @gear public readonly formApi!: FormApi;
-          @gear public readonly state!: FormState<unknown>;
+          @gear() public readonly formApi!: FormApi;
+          @gear() public readonly state!: FormState<unknown>;
 
           public constructor() {
             super();
@@ -451,7 +492,7 @@ describe('@corpuscule/form', () => {
 
           public disconnectedCallback(): void {}
 
-          @option
+          @option()
           public onSubmit(): void {}
         }
       }).not.toThrow();

--- a/packages/form/src/field.js
+++ b/packages/form/src/field.js
@@ -30,7 +30,7 @@ const field = (
   let $validate;
   let $validateFields;
 
-  const [sharedPropertiesRegistry] = tokenRegistry.get(token);
+  const sharedPropertiesRegistry = tokenRegistry.get(token);
   const isNativeField = isNativeElement(klass.prototype);
 
   const $$connected = Symbol();

--- a/packages/form/src/form.js
+++ b/packages/form/src/form.js
@@ -2,9 +2,8 @@ import {provider} from '@corpuscule/context';
 import {assertRequiredProperty} from '@corpuscule/utils/lib/asserts';
 import defineExtendable from '@corpuscule/utils/lib/defineExtendable';
 import reflectClassMethods from '@corpuscule/utils/lib/reflectClassMethods';
-import {getName} from '@corpuscule/utils/lib/propertyUtils';
 import {createForm, formSubscriptionItems} from 'final-form';
-import {tokenRegistry} from './utils';
+import {formOptionResponsibilityKeys, tokenRegistry} from './utils';
 
 export const all = formSubscriptionItems.reduce((result, key) => {
   result[key] = true;
@@ -15,10 +14,11 @@ export const all = formSubscriptionItems.reduce((result, key) => {
 const form = (token, {decorators = [], subscription = all} = {}) => klass => {
   let $formApi;
   let $state;
-  let formOptions;
+  let $onSubmit;
+  let sharedProperties;
 
   const {prototype} = klass;
-  const [sharedPropertiesRegistry, formOptionsRegistry] = tokenRegistry.get(token);
+  const sharedPropertiesRegistry = tokenRegistry.get(token);
 
   const $$reset = Symbol();
   const $$submit = Symbol();
@@ -27,16 +27,11 @@ const form = (token, {decorators = [], subscription = all} = {}) => klass => {
   const supers = reflectClassMethods(prototype, ['connectedCallback', 'disconnectedCallback']);
 
   klass.__registrations.push(() => {
-    ({formApi: $formApi, state: $state} = sharedPropertiesRegistry.get(klass) || {});
-    formOptions = formOptionsRegistry.get(klass) || [];
+    sharedProperties = sharedPropertiesRegistry.get(klass) || {};
+    ({formApi: $formApi, state: $state, onSubmit: $onSubmit} = sharedProperties);
     assertRequiredProperty('form', 'gear', 'form', $formApi);
     assertRequiredProperty('form', 'gear', 'state', $state);
-    assertRequiredProperty(
-      'form',
-      'option',
-      'onSubmit',
-      formOptions.find(key => getName(key) === 'onSubmit'),
-    );
+    assertRequiredProperty('form', 'option', 'onSubmit', $onSubmit);
   });
 
   defineExtendable(
@@ -83,8 +78,10 @@ const form = (token, {decorators = [], subscription = all} = {}) => klass => {
     Object.assign(self, {
       // Fields
       [$formApi]: createForm(
-        formOptions.reduce((acc, key) => {
-          acc[key] = self[key];
+        formOptionResponsibilityKeys.reduce((acc, key) => {
+          if (sharedProperties[key]) {
+            acc[key] = self[sharedProperties[key]];
+          }
 
           return acc;
         }, {}),

--- a/packages/form/src/gear.js
+++ b/packages/form/src/gear.js
@@ -1,19 +1,19 @@
 import {value} from '@corpuscule/context';
 import {getName} from '@corpuscule/utils/lib/propertyUtils';
 import {setObject} from '@corpuscule/utils/lib/setters';
-import {gears, tokenRegistry} from './utils';
+import {gearsResponsibilityKeys, tokenRegistry} from './utils';
 
-const gear = token => (prototype, propertyKey, descriptor) => {
+const gear = (token, responsibilityKey) => (prototype, propertyKey, descriptor) => {
   const {constructor: klass} = prototype;
-  const name = getName(propertyKey);
+  const finalResponsibilityKey = responsibilityKey || getName(propertyKey);
 
-  if (!gears.includes(name)) {
-    throw new TypeError(`Property name ${name} is not allowed`);
+  if (!gearsResponsibilityKeys.includes(finalResponsibilityKey)) {
+    throw new TypeError(`Property name ${finalResponsibilityKey} is not allowed`);
   }
 
-  const [sharedPropertiesRegistry] = tokenRegistry.get(token);
+  const sharedPropertiesRegistry = tokenRegistry.get(token);
 
-  if (name === 'refs') {
+  if (finalResponsibilityKey === 'refs') {
     let $ref;
 
     klass.__registrations.push(() => {
@@ -29,10 +29,12 @@ const gear = token => (prototype, propertyKey, descriptor) => {
   }
 
   setObject(sharedPropertiesRegistry, klass, {
-    [name]: propertyKey,
+    [finalResponsibilityKey]: propertyKey,
   });
 
-  return name === 'formApi' ? value(token)(prototype, propertyKey, descriptor) : descriptor;
+  return finalResponsibilityKey === 'formApi'
+    ? value(token)(prototype, propertyKey, descriptor)
+    : descriptor;
 };
 
 export default gear;

--- a/packages/form/src/gear.js
+++ b/packages/form/src/gear.js
@@ -1,13 +1,13 @@
 import {value} from '@corpuscule/context';
 import {getName} from '@corpuscule/utils/lib/propertyUtils';
 import {setObject} from '@corpuscule/utils/lib/setters';
-import {gearsResponsibilityKeys, tokenRegistry} from './utils';
+import {gearResponsibilityKeys, tokenRegistry} from './utils';
 
 const gear = (token, responsibilityKey) => (prototype, propertyKey, descriptor) => {
   const {constructor: klass} = prototype;
   const finalResponsibilityKey = responsibilityKey || getName(propertyKey);
 
-  if (!gearsResponsibilityKeys.includes(finalResponsibilityKey)) {
+  if (!gearResponsibilityKeys.includes(finalResponsibilityKey)) {
     throw new TypeError(`Property name ${finalResponsibilityKey} is not allowed`);
   }
 

--- a/packages/form/src/index.d.ts
+++ b/packages/form/src/index.d.ts
@@ -44,7 +44,7 @@ export interface FormDecoratorOptions {
  * one case when all your properties are string and you do not plan to use
  * specific property names.
  */
-export interface FormGears<TFormValues> {
+export interface FormGears<TFormValues = object> {
   /**
    * Contains a form instance and allows working with the
    * [🏁 FinalForm API](https://github.com/final-form/final-form#formapi).
@@ -150,7 +150,7 @@ export interface FieldGears<TFieldValue> {
  */
 export type FieldOptions<TFieldValue> = Omit<
   FieldState<TFieldValue>,
-  'blur' | 'change' | 'focus' | 'length' | 'name' | 'value'
+  'blur' | 'change' | 'focus' | 'length'
 >;
 
 export interface FieldInputProps<TFieldValue> {
@@ -165,7 +165,7 @@ export interface FieldInputProps<TFieldValue> {
   readonly value: TFieldValue;
 }
 
-export type FieldMetaProps<TFieldValue> = FieldOptions<TFieldValue>;
+export type FieldMetaProps<TFieldValue> = Omit<FieldOptions<TFieldValue>, 'name' | 'value'>;
 
 /**
  * Creates tokens to bind decorators with each other.
@@ -176,7 +176,9 @@ export function createFormToken(): Token;
  * A default version of the [@gearAdvanced]{@link @corpuscule/form.gearAdvanced}
  * with the token already provided.
  */
-export const gear: PropertyDecorator;
+export function gear(
+  responsibilityKey?: keyof FormGears | keyof FieldGears<unknown>,
+): PropertyDecorator;
 
 /**
  * A default version of the [@fieldAdvanced]{@link @corpuscule/form.fieldAdvanced}
@@ -200,7 +202,9 @@ export function isForm(klass: unknown): boolean;
  * A default version of the [@optionAdvanced]{@link @corpuscule/form.optionAdvanced}
  * with the token already provided.
  */
-export const option: PropertyDecorator;
+export function option(
+  responsibilityKey?: keyof FormOptions | keyof FieldOptions<unknown>,
+): PropertyDecorator;
 
 /**
  * A decorator that converts a class property to a part of the 🏁 Final Form
@@ -216,8 +220,16 @@ export const option: PropertyDecorator;
  *
  * @param token a token issued by a [[createFormToken]] function that connects
  * all decorators in a single working system.
+ *
+ * @param responsibilityKey a specific name of a gear that describes the
+ * responsibility of the property this decorator is applied to. If it is
+ * omitted, the name (or the description if it is a symbol) of the property will
+ * be used.
  */
-export function gearAdvanced(token: Token): PropertyDecorator;
+export function gearAdvanced(
+  token: Token,
+  responsibilityKey?: keyof FormGears | keyof FieldGears<unknown>,
+): PropertyDecorator;
 
 /**
  * A decorator that makes a class declaration a 🏁 FinalForm field with a form
@@ -264,5 +276,13 @@ export const isFormAdvanced: typeof isProvider;
  *
  * @param token a token issued by a [[createFormToken]] function that connects
  * all decorators in a single working system.
+ *
+ * @param responsibilityKey a specific name of an option that describes the
+ * responsibility of the property this decorator is applied to. If it is
+ * omitted, the name (or the description if it is a symbol) of the property will
+ * be used.
  */
-export function optionAdvanced(token: Token): PropertyDecorator;
+export function optionAdvanced(
+  token: Token,
+  responsibilityKey?: keyof FormOptions | keyof FieldOptions<unknown>,
+): PropertyDecorator;

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -16,8 +16,8 @@ export {
 
 const defaultToken = createFormToken();
 
-export const gear = gearAdvanced(defaultToken);
+export const gear = responsibilityKey => gearAdvanced(defaultToken, responsibilityKey);
 export const field = options => fieldAdvanced(defaultToken, options);
 export const form = options => formAdvanced(defaultToken, options);
 export const isForm = klass => isProvider(defaultToken, klass);
-export const option = optionAdvanced(defaultToken);
+export const option = responsibilityKey => optionAdvanced(defaultToken, responsibilityKey);

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -3,20 +3,17 @@ import createTokenRegistry from '@corpuscule/utils/lib/tokenRegistry';
 import {configOptions} from 'final-form';
 
 export const [createFormToken, tokenRegistry] = createTokenRegistry(
-  () => [
-    new WeakMap(), // Shared properties list
-    new WeakMap(), // Form configuration options list
-  ],
+  () => new WeakMap(), // Shared properties list
   createContextToken,
 );
 
 export const noop = () => {}; // eslint-disable-line no-empty-function
 
-export const formOptions = [...configOptions, 'compareInitialValues'];
+export const formOptionResponsibilityKeys = [...configOptions, 'compareInitialValues'];
 
-export const gears = ['formApi', 'input', 'meta', 'refs', 'state'];
+export const gearsResponsibilityKeys = ['formApi', 'input', 'meta', 'refs', 'state'];
 
-export const fieldOptions = [
+export const fieldOptionResponsibilityKeys = [
   'format',
   'formatOnBlur',
   'isEqual',

--- a/packages/form/src/utils.js
+++ b/packages/form/src/utils.js
@@ -11,7 +11,7 @@ export const noop = () => {}; // eslint-disable-line no-empty-function
 
 export const formOptionResponsibilityKeys = [...configOptions, 'compareInitialValues'];
 
-export const gearsResponsibilityKeys = ['formApi', 'input', 'meta', 'refs', 'state'];
+export const gearResponsibilityKeys = ['formApi', 'input', 'meta', 'refs', 'state'];
 
 export const fieldOptionResponsibilityKeys = [
   'format',


### PR DESCRIPTION
This PR introduces an ability to set a custom name for the properties that work as form gears or form options.

Before this PR, the name the gear/option property could have was restricted: it reflected the responsibility the property has. E.g., the property that serves as a `formApi` could be named only `formApi`. But now you can specify the property responsibility as a decorator parameter and use whatever name you want for this property.

It looks like the following:
```typescript
@form()
class Form extends HTMLElement {
  @gear('formApi') private someCustomNameForFormApiProperty!: FormApi;
  @gear('state') private someCustomNameForFormState!: FormState<object>;

  @option('onSubmit')
  private someCustomNameForOnSubmitOption(values: object): void {
    // method body
  }
}
```

If you want to have the previous behavior, you should just omit the `responsibilityKey` decorator parameter leaving the decorator parenthesis empty. This way, the name of the property will be used.

## Breaking changes
This change is breaking because it requires `@gear` and `@option` decorators to have parenthesis while they shouldn't have them before.