### PR TITLE
Allow specifying custom route context data

### DIFF
--- a/packages/router/__tests__/Link.ts
+++ b/packages/router/__tests__/Link.ts
@@ -22,14 +22,15 @@ describe('@corpuscule/router', () => {
       historyStateSpy = spyOnProperty(history, 'state').and.returnValue('/test');
     });
 
-    it("should be accessible through 'document.createElement'", () => {
+    it("accessible through 'document.createElement'", () => {
       expect(link).toEqual(jasmine.any(Link));
     });
 
-    it('should dispatch PopStateEvent with current history state by click', done => {
+    it('dispatches PopStateEvent with current history state by click', done => {
       document.body.appendChild(link);
+
       const listener = (e: PopStateEvent) => {
-        expect(e.state).toEqual('/test');
+        expect(e.state).toEqual({data: undefined, path: '/test'});
 
         window.removeEventListener('popstate', listener);
         done();
@@ -40,7 +41,7 @@ describe('@corpuscule/router', () => {
       link.click();
     });
 
-    it('should prevent default action for a anchor element', done => {
+    it('prevents default action for a anchor element', done => {
       document.body.appendChild(link);
       link.addEventListener('click', e => {
         expect(e.defaultPrevented).toBeTruthy();

--- a/packages/router/__tests__/Link.ts
+++ b/packages/router/__tests__/Link.ts
@@ -50,5 +50,23 @@ describe('@corpuscule/router', () => {
 
       link.click();
     });
+
+    it('allows changing the context for the link', done => {
+      const data = {};
+      document.body.appendChild(link);
+
+      const listener = (e: PopStateEvent) => {
+        expect(e.state).toEqual({data, path: '/test'});
+
+        window.removeEventListener('popstate', listener);
+        done();
+      };
+
+      window.addEventListener('popstate', listener);
+
+      link.contextData = data;
+
+      link.click();
+    });
   });
 });

--- a/packages/router/__tests__/context.ts
+++ b/packages/router/__tests__/context.ts
@@ -2,21 +2,17 @@ import UniversalRouter, {Route} from 'universal-router';
 import {createSimpleContext} from '../../../test/utils';
 import {gear, outlet, provider} from '../src';
 
-interface RoutingChainElement {
-  readonly result: unknown;
-  readonly route: Route;
-}
-
 describe('@corpuscule/router', () => {
   describe('context', () => {
+    let data: object;
     let route: Route;
     let router: jasmine.SpyObj<UniversalRouter>;
-    let resolvedChain: readonly RoutingChainElement[];
 
     beforeEach(() => {
+      data = {};
       route = {};
       router = jasmine.createSpyObj('router', ['resolve']);
-      resolvedChain = [{result: 'Foo', route}];
+      const resolvedChain = [{result: 'Foo', route}];
       router.resolve.and.callFake(async () => resolvedChain);
     });
 
@@ -35,6 +31,7 @@ describe('@corpuscule/router', () => {
 
       expect(router.resolve).toHaveBeenCalledWith({
         chain: [],
+        data: undefined,
         pathname: '/',
       });
 
@@ -55,10 +52,11 @@ describe('@corpuscule/router', () => {
       await createSimpleContext(Provider, Outlet);
       router.resolve.calls.reset();
 
-      window.dispatchEvent(new PopStateEvent('popstate', {state: '/foo/bar'}));
+      window.dispatchEvent(new PopStateEvent('popstate', {state: {data, path: '/foo/bar'}}));
 
       expect(router.resolve).toHaveBeenCalledWith({
         chain: [],
+        data,
         pathname: '/foo/bar',
       });
     });
@@ -87,7 +85,7 @@ describe('@corpuscule/router', () => {
       }
 
       await createSimpleContext(Provider, Outlet);
-      window.dispatchEvent(new PopStateEvent('popstate', {state: '/foo/bar'}));
+      window.dispatchEvent(new PopStateEvent('popstate', {state: {data, path: '/foo/bar'}}));
 
       expect(outputSpy).not.toHaveBeenCalled();
     });

--- a/packages/router/__tests__/navigate.ts
+++ b/packages/router/__tests__/navigate.ts
@@ -3,28 +3,26 @@ import {navigate} from '../src';
 describe('@corpuscule/router', () => {
   describe('navigate', () => {
     let historyPushStateSpy: jasmine.Spy;
-    let historyStateSpy: jasmine.Spy;
+    let data: object;
 
     afterAll(() => {
-      historyStateSpy.and.callThrough();
       historyPushStateSpy.and.callThrough();
     });
 
     beforeEach(() => {
+      data = {};
       historyPushStateSpy = spyOn(history, 'pushState');
-      historyStateSpy = spyOnProperty(history, 'state').and.returnValue('/test');
     });
 
-    it('should push new state to history', () => {
-      navigate('/test');
+    it('pushes the new state to the history', () => {
+      navigate('/test', data);
       // tslint:disable-next-line:no-unbound-method
-      expect(history.pushState).toHaveBeenCalledWith('/test', null, '/test');
-      expect(historyStateSpy).toHaveBeenCalled();
+      expect(history.pushState).toHaveBeenCalledWith({data, path: '/test'}, null, '/test');
     });
 
-    it("should dispatch 'popstate' event", done => {
+    it("dispatches the 'popstate' event", done => {
       const listener = (e: PopStateEvent) => {
-        expect(e.state).toEqual('/test');
+        expect(e.state).toEqual({data, path: '/test'});
 
         window.removeEventListener('popstate', listener);
         done();
@@ -32,7 +30,7 @@ describe('@corpuscule/router', () => {
 
       window.addEventListener('popstate', listener);
 
-      navigate('/test');
+      navigate('/test', data);
     });
   });
 });

--- a/packages/router/src/Link.js
+++ b/packages/router/src/Link.js
@@ -22,7 +22,7 @@ export default class Link extends HTMLAnchorElement {
 
   [$$handleClick](e) {
     e.preventDefault();
-    navigate(`${this.pathname}${this.search}${this.hash}`);
+    navigate(`${this.pathname}${this.search}${this.hash}`, this.contextData);
   }
 }
 

--- a/packages/router/src/index.d.ts
+++ b/packages/router/src/index.d.ts
@@ -62,8 +62,18 @@ export class Link extends HTMLAnchorElement implements CustomElement {
  * A function that navigates the browser to the new URL.
  *
  * @param path a new URL to navigate to.
+ *
+ * @param contextData some data you want to use in the route action. It will be
+ * accessible as a part of the `context` parameter:
+ * ```typescript
+ * const route: Route<any, any> = {
+ *   action({data}: RouteContext<any, any>) {
+ *     // use `data` in some way
+ *   }
+ * }
+ * ```
  */
-export function navigate(path: string): void;
+export function navigate(path: string, contextData?: unknown): void;
 
 /**
  * Creates tokens to bind decorators with each other.

--- a/packages/router/src/index.d.ts
+++ b/packages/router/src/index.d.ts
@@ -53,6 +53,12 @@ export class Link extends HTMLAnchorElement implements CustomElement {
    */
   public static readonly is: 'corpuscule-link';
 
+  /**
+   * A custom context data that will be send as a second parameter to the
+   * [[navigate]] function.
+   */
+  public contextData: any;
+
   public connectedCallback(): void;
 
   public disconnectedCallback(): void;

--- a/packages/router/src/navigate.js
+++ b/packages/router/src/navigate.js
@@ -1,6 +1,7 @@
-const navigate = path => {
-  history.pushState(path, null, path);
-  dispatchEvent(new PopStateEvent('popstate', {state: history.state}));
+const navigate = (path, contextData) => {
+  const state = {data: contextData, path};
+  history.pushState(state, null, path);
+  dispatchEvent(new PopStateEvent('popstate', {state}));
 };
 
 export default navigate;

--- a/packages/router/src/provider.js
+++ b/packages/router/src/provider.js
@@ -41,12 +41,13 @@ const provider = (token, {initialPath = location.pathname} = {}) => klass => {
   Object.defineProperty(prototype, $$providingValue, valueDescriptor);
 
   klass.__initializers.push(self => {
-    self[$$updateRoute] = async ({state: pathname = initialPath} = {}) => {
+    self[$$updateRoute] = async ({state: {path = initialPath, data} = {}} = {}) => {
       self[$$providingValue] = await self[$router].resolve({
         // This array goes to the resolveRoute function and fills with the
         // passed routes.
         chain: [],
-        pathname,
+        data,
+        pathname: path,
       });
     };
   });


### PR DESCRIPTION
This PR introduces a mechanism to share some data from the place where the `navigate` function (or a Link instance) is used to the route action method. It makes the router way more flexible than it was before because now you can tune it in details relying on the internal data of the component that performs navigation.

It works the following way:
```typescript
const data = {foo: 'bar'};
navigate('/foo', data);

const route = {
  action({data}: RouteContext<any, any>) {
    console.log(data.foo); // prints "bar"
  }
}
```
The same way it works with the `Link` component.
```html
<a id="link" is="corpuscule-link">Click me</a>
```
```typescript
const link = document.getElementById('link');
link.contextData = {foo: 'bar'};

const route = {
  action({data}: RouteContext<any, any>) {
    console.log(data.foo); // prints "bar"
  }
}

link.click();
```