### PR TITLE
Add support for CSSStyleSheet object

### DIFF
--- a/packages/styles/src/index.d.ts
+++ b/packages/styles/src/index.d.ts
@@ -98,9 +98,21 @@ export interface StylesDecoratorOptions {
  * component `ShadowRoot` as if a browser defined it. No intermediate `<style>`
  * tag is required.
  *
- * This approach is used if the element is a string and
- * [adoptedStyleSheets]{@link StylesDecoratorOptions.adoptedStyleSheets} is
- * enabled.
+ * There are two approaches this function supports.
+ *
+ * #### Adopt existing stylesheet
+ * If you provide a `CSSStyleSheet` object as an element of the `pathsOrStyles`
+ * array, it will just be adopted.
+ *
+ * This approach will be used whether the [adoptedStyleSheets]{@link StylesDecoratorOptions.adoptedStyleSheets}
+ * is enabled or not. Providing `CSSStyleSheet` object is enough.
+ *
+ * #### Create new stylesheet
+ * If you provide a string as an element of the `pathsOrStyles` array, the new
+ * `CSSStyleSheet` object will be created and adopted.
+ *
+ * This approach will be used if [adoptedStyleSheets]{@link StylesDecoratorOptions.adoptedStyleSheets}
+ * is enabled.
  *
  * ### ShadyCSS
  * `ShadyCSS` provides support for a Constructible Stylesheets proposal, so
@@ -129,13 +141,13 @@ export interface StylesDecoratorOptions {
  * ```
  *
  * @param pathsOrStyles an array with paths to the CSS files (as `URL`
- * instances) or strings with CSS code.
+ * instances), `CSSStyleSheet` objects or strings with CSS code.
  *
  * @param options an object that contains options to change the default
  * behavior of the decorator.
  */
 export function stylesAdvanced(
-  pathsOrStyles: Array<string | URL>,
+  pathsOrStyles: Array<string | URL | CSSStyleSheet>,
   options?: StylesDecoratorOptions,
 ): ClassDecorator;
 
@@ -150,4 +162,6 @@ export function stylesAdvanced(
  * ShadyCSS polyfill is used, and its support for the native shadow root is not
  * activated.
  */
-export default function styles(...pathsOrStyles: Array<string | URL>): ClassDecorator;
+export default function styles(
+  ...pathsOrStyles: Array<string | URL | CSSStyleSheet>
+): ClassDecorator;

--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -15,7 +15,7 @@ export const stylesAdvanced = (
   const {prototype} = klass;
   const linkNodes = document.createDocumentFragment();
   const styleNodes = document.createDocumentFragment();
-  const constructableStyles = [];
+  const constructedStyles = [];
 
   for (const pathOrStyle of pathsOrStyles) {
     if (pathOrStyle instanceof URL) {
@@ -28,14 +28,18 @@ export const stylesAdvanced = (
           ? pathOrStyle.pathname + pathOrStyle.search
           : pathOrStyle;
       linkNodes.append(link);
+    } else if (pathOrStyle instanceof CSSStyleSheet) {
+      // If there is support for CSS Modules or emulation like with the
+      // @corpuscule/construct-stylesheet-loader
+      constructedStyles.push(pathOrStyle);
     } else if (shadyCSS) {
       // If ShadyCSS
-      constructableStyles.push(pathOrStyle);
+      constructedStyles.push(pathOrStyle);
     } else if (adoptedStyleSheets) {
-      // If there is support for Constructable Style Sheets proposal
+      // If there is support for Constructible Style Sheets proposal
       const sheet = new CSSStyleSheet();
       sheet.replaceSync(pathOrStyle);
-      constructableStyles.push(sheet);
+      constructedStyles.push(sheet);
     } else {
       // Otherwise, just create a style tag
       const style = document.createElement('style');
@@ -49,11 +53,11 @@ export const stylesAdvanced = (
   klass.prototype.attachShadow = function attachShadow(options) {
     const root = supers.attachShadow.call(this, options);
 
-    if (constructableStyles.length > 0) {
+    if (constructedStyles.length > 0) {
       if (shadyCSS) {
-        window.ShadyCSS.prepareAdoptedCssText(constructableStyles, this.localName);
+        window.ShadyCSS.prepareAdoptedCssText(constructedStyles, this.localName);
       } else {
-        root.adoptedStyleSheets = constructableStyles;
+        root.adoptedStyleSheets = constructedStyles;
       }
     }
 


### PR DESCRIPTION
This PR introduces a new feature for the `@corpuscule/styles` package that allows adopting the already created `CSSStyleSheet` object in the `@styles` decorator. It is a part of supporting upcoming [CSS Modules proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/master/CSSModules/v1Explainer.md).

### Example
```typescript
import styles from '@corpuscule/styles';

const sheet = new CSSStyleSheet();
sheet.replaceSync(':host { width: 100% }')

@styles(sheet)
class StyledComponent extends HTMLElement {}
```