### PR TITLE
Run property and internal callbacks after the actual property is assigned

### DIFF
--- a/packages/element/__tests__/internal.ts
+++ b/packages/element/__tests__/internal.ts
@@ -77,5 +77,24 @@ describe('@corpuscule/element', () => {
       expect(internalChangedCallbackSpy).toHaveBeenCalledWith('accessor', 'str', 'test');
       expect(internalChangedCallbackSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('runs [internalChangedCallback] after the property is set', () => {
+      const internalChangedCallbackSpy = jasmine.createSpy('onInternalChanged');
+
+      class Test extends CorpusculeElementMock {
+        @internal
+        public prop: number = 10;
+
+        public [internalChangedCallback](_name: string, _oldValue: number, newValue: number): void {
+          internalChangedCallbackSpy();
+          expect(this.prop).toBe(newValue);
+        }
+      }
+
+      const test = new Test();
+      test.prop = 20;
+
+      expect(internalChangedCallbackSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/element/__tests__/property.ts
+++ b/packages/element/__tests__/property.ts
@@ -91,6 +91,25 @@ describe('@corpuscule/element', () => {
       expect(propertyChangedCallbackSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('runs [propertyChangedCallback] after the property is set', () => {
+      const propertyChangedCallbackSpy = jasmine.createSpy('onPropertyChanged');
+
+      class Test extends CorpusculeElementMock {
+        @property()
+        public prop: number = 10;
+
+        public [propertyChangedCallback](_name: string, _oldValue: number, newValue: number): void {
+          propertyChangedCallbackSpy();
+          expect(this.prop).toBe(newValue);
+        }
+      }
+
+      const test = new Test();
+      test.prop = 20;
+
+      expect(propertyChangedCallbackSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('throws an error if value does not fit guard', () => {
       class Test extends CorpusculeElementMock {
         @property((v: any) => typeof v === 'number')

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -106,6 +106,8 @@ export interface ElementGears {
    * `attributeChangedCallback`. It does trigger an update each time it is
    * invoked.
    *
+   * The callback is called right AFTER the property is assigned.
+   *
    * @param propertyName a property name (either string or symbolic).
    * @param oldValue a value of the property that was before the update started.
    * @param newValue a new value to set to the property.
@@ -117,6 +119,8 @@ export interface ElementGears {
    * property is assigned. The behavior is identical to
    * `attributeChangedCallback`. It does not trigger a re-rendering if the
    * `oldValue` is equal to `newValue` (by the strict equality check `===`).
+   *
+   * The callback is called right AFTER the property is assigned.
    *
    * @param propertyName a property name (either string or symbolic).
    * @param oldValue a value of the property that was before the update started.

--- a/packages/element/src/internal.js
+++ b/packages/element/src/internal.js
@@ -8,8 +8,9 @@ const internal = ({constructor: klass}, propertyKey, descriptor) => {
     configurable: true,
     get,
     set(value) {
-      this[$internalChangedCallback](propertyKey, get.call(this), value);
+      const oldValue = get.call(this);
       set.call(this, value);
+      this[$internalChangedCallback](propertyKey, oldValue, value);
     },
   };
 };

--- a/packages/element/src/property.js
+++ b/packages/element/src/property.js
@@ -12,8 +12,9 @@ const property = (guard = () => true) => ({constructor: klass}, propertyKey, des
         throw new TypeError(`Value applied to "${propertyKey}" has wrong type`);
       }
 
-      this[$propertyChangedCallback](propertyKey, get.call(this), value);
+      const oldValue = get.call(this);
       set.call(this, value);
+      this[$propertyChangedCallback](propertyKey, oldValue, value);
     },
   };
 };


### PR DESCRIPTION
This PR fixes an issue when the actual property during the `propertyChangedCallback` or `internalChangedCallback` is still equal to an `oldValue` rather than `newValue`. It leads to strange cases when user tries to call a method that uses the property expecting that the value is already updated but the method fails because it is not.