### PR TITLE
Add lightDOM option for query selectors

### DIFF
--- a/packages/element/__tests__/query.ts
+++ b/packages/element/__tests__/query.ts
@@ -32,7 +32,7 @@ describe('@corpuscule/element', () => {
       expect(test.target.textContent).toBe('Test text');
     });
 
-    it('finds element in lightDOM', async () => {
+    it('finds element in Light DOM', async () => {
       class Test extends HTMLElement {
         @query('#target')
         public target!: HTMLElement;
@@ -55,7 +55,7 @@ describe('@corpuscule/element', () => {
       expect(test.target.textContent).toBe('Test text');
     });
 
-    it('can work in the light DOM even if Shadow DOM is enabled', async () => {
+    it('can work in the Light DOM even if Shadow DOM is enabled', async () => {
       class Test extends HTMLElement {
         @query('#target', {lightDOM: true})
         public target!: HTMLElement;
@@ -123,7 +123,7 @@ describe('@corpuscule/element', () => {
       expect(test.targets[2].textContent).toBe('Test 3');
     });
 
-    it('finds all elements in light DOM', async () => {
+    it('finds all elements in Light DOM', async () => {
       class Test extends HTMLElement {
         @queryAll('.target')
         public targets!: NodeList;
@@ -151,7 +151,7 @@ describe('@corpuscule/element', () => {
       expect(test.targets[2].textContent).toBe('Test 3');
     });
 
-    it('can work with lightDOM even if ShadowDOM is enabled', async () => {
+    it('can work with Light DOM even if Shadow DOM is enabled', async () => {
       class Test extends HTMLElement {
         @queryAll('.target', {lightDOM: true})
         public targets!: NodeList;

--- a/packages/element/__tests__/query.ts
+++ b/packages/element/__tests__/query.ts
@@ -54,13 +54,45 @@ describe('@corpuscule/element', () => {
       expect(test.target).toEqual(jasmine.any(HTMLElement));
       expect(test.target.textContent).toBe('Test text');
     });
+
+    it('can work in the light DOM even if Shadow DOM is enabled', async () => {
+      class Test extends HTMLElement {
+        @query('#target', {lightDOM: true})
+        public target!: HTMLElement;
+
+        public constructor() {
+          super();
+
+          this.attachShadow({mode: 'open'});
+        }
+
+        public connectedCallback(): void {
+          // tslint:disable-next-line:no-inner-html
+          this.innerHTML = `
+            <div></div>
+            <div class="wrapper">
+              <div id="target">Test text</div>
+            </div>
+          `;
+
+          // tslint:disable-next-line:no-inner-html
+          this.shadowRoot!.innerHTML = `<div id="target">Another text</div>`;
+        }
+      }
+
+      const tag = defineCE(Test);
+      const test = await fixture<Test>(`<${tag}></${tag}>`);
+
+      expect(test.target).toEqual(jasmine.any(HTMLElement));
+      expect(test.target.textContent).toBe('Test text');
+    });
   });
 
   describe('@queryAll', () => {
     it('finds all elements in shadow root', async () => {
       class Test extends HTMLElement {
         @queryAll('.target')
-        public targets!: HTMLElement;
+        public targets!: NodeList;
 
         public constructor() {
           super();
@@ -85,6 +117,7 @@ describe('@corpuscule/element', () => {
       const test = await fixture<Test>(`<${tag}></${tag}>`);
 
       expect(test.targets).toEqual(jasmine.any(NodeList));
+      expect(test.targets.length).toBe(3);
       expect(test.targets[0].textContent).toBe('Test 1');
       expect(test.targets[1].textContent).toBe('Test 2');
       expect(test.targets[2].textContent).toBe('Test 3');
@@ -93,7 +126,7 @@ describe('@corpuscule/element', () => {
     it('finds all elements in light DOM', async () => {
       class Test extends HTMLElement {
         @queryAll('.target')
-        public targets!: HTMLElement;
+        public targets!: NodeList;
 
         public connectedCallback(): void {
           // tslint:disable-next-line:no-inner-html
@@ -112,6 +145,41 @@ describe('@corpuscule/element', () => {
       const test = await fixture<Test>(`<${tag}></${tag}>`);
 
       expect(test.targets).toEqual(jasmine.any(NodeList));
+      expect(test.targets.length).toBe(3);
+      expect(test.targets[0].textContent).toBe('Test 1');
+      expect(test.targets[1].textContent).toBe('Test 2');
+      expect(test.targets[2].textContent).toBe('Test 3');
+    });
+
+    it('can work with lightDOM even if ShadowDOM is enabled', async () => {
+      class Test extends HTMLElement {
+        @queryAll('.target', {lightDOM: true})
+        public targets!: NodeList;
+
+        public constructor() {
+          super();
+
+          this.attachShadow({mode: 'open'});
+        }
+
+        public connectedCallback(): void {
+          // tslint:disable-next-line:no-inner-html
+          this.innerHTML = `
+            <div></div>
+            <div class="wrapper">
+              <div class="target">Test 1</div>
+              <div class="target">Test 2</div>
+              <div class="target">Test 3</div>
+            </div>
+          `;
+        }
+      }
+
+      const tag = defineCE(Test);
+      const test = await fixture<Test>(`<${tag}></${tag}>`);
+
+      expect(test.targets).toEqual(jasmine.any(NodeList));
+      expect(test.targets.length).toBe(3);
       expect(test.targets[0].textContent).toBe('Test 1');
       expect(test.targets[1].textContent).toBe('Test 2');
       expect(test.targets[2].textContent).toBe('Test 3');

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -233,6 +233,14 @@ export interface ElementDecoratorOptions {
 
 export type PropertyGuard = (value: unknown) => boolean;
 
+export interface QueryOptions {
+  /**
+   * This option allows query selector to perform searching not in the Light
+   * DOM instead of Shadow DOM.
+   */
+  readonly lightDOM?: boolean;
+}
+
 /**
  * A decorator that binds a class property to an appropriate attribute and
  * provides a transformation to the property value to and from the attribute
@@ -468,8 +476,9 @@ export function property(guard?: PropertyGuard): PropertyDecorator;
  * ```
  *
  * @param selector a selector of the desired element.
+ * @param options a set of decorator options
  */
-export function query(selector: string): PropertyDecorator;
+export function query(selector: string, options?: QueryOptions): PropertyDecorator;
 
 /**
  * A decorator that converts a property to a getter that finds all elements
@@ -495,8 +504,9 @@ export function query(selector: string): PropertyDecorator;
  * ```
  *
  * @param selector a selector of the desired set of elements.
+ * @param options a set of decorator options
  */
-export function queryAll(selector: string): PropertyDecorator;
+export function queryAll(selector: string, options?: QueryOptions): PropertyDecorator;
 
 /**
  * By default, [computed]{@link computer} and [observed]{@link observer}

--- a/packages/element/src/index.d.ts
+++ b/packages/element/src/index.d.ts
@@ -236,7 +236,7 @@ export type PropertyGuard = (value: unknown) => boolean;
 export interface QueryOptions {
   /**
    * This option allows query selector to perform searching not in the Light
-   * DOM instead of Shadow DOM.
+   * DOM instead of the Shadow DOM.
    */
   readonly lightDOM?: boolean;
 }

--- a/packages/element/src/query.js
+++ b/packages/element/src/query.js
@@ -1,9 +1,11 @@
-const executeQuery = callback => ({
+const executeQuery = (callback, {lightDOM = false} = {}) => ({
   configurable: true,
   get() {
-    return callback(this.shadowRoot || this);
+    return callback(this.shadowRoot && !lightDOM ? this.shadowRoot : this);
   },
 });
 
-export const query = selector => () => executeQuery(root => root.querySelector(selector));
-export const queryAll = selector => () => executeQuery(root => root.querySelectorAll(selector));
+export const query = (selector, options) => () =>
+  executeQuery(root => root.querySelector(selector), options);
+export const queryAll = (selector, options) => () =>
+  executeQuery(root => root.querySelectorAll(selector), options);


### PR DESCRIPTION
While `@query` and `@queryAll` are able to perform searching in the ShadowDOM, they are currently unable to do it in the LightDOM when the shadow root is attached. This PR adds an ability to search in the LightDOM even if the ShadowDOM is enabled.